### PR TITLE
chore: prepare repository for public release (Phase 4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewer for all changes.
+# Used by branch protection "Require review from Code Owners".
+*       @henrik-me

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a defect or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the sections below so we can reproduce the issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: Describe the unexpected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered list of steps to reproduce the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (React PWA)
+        - Backend (.NET API)
+        - Offline / service worker
+        - Quiz / study flow
+        - State selection / representatives
+        - Build / CI / Docker
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit SHA
+      placeholder: e.g. v1.2.3 or main@abc1234
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, .NET/Node versions, deployment (local / container / Azure).
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/henrik-me/NaturalizationPuzzle/security/advisories/new
     about: Report a security issue privately (do not open a public issue).
-  - name: Question / discussion
-    url: https://github.com/henrik-me/NaturalizationPuzzle/discussions
-    about: Ask a question or start a discussion (if Discussions are enabled).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/henrik-me/NaturalizationPuzzle/security/advisories/new
+    about: Report a security issue privately (do not open a public issue).
+  - name: Question / discussion
+    url: https://github.com/henrik-me/NaturalizationPuzzle/discussions
+    about: Ask a question or start a discussion (if Discussions are enabled).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an idea or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user need or pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should happen? How should it behave?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (React PWA)
+        - Backend (.NET API)
+        - Offline / service worker
+        - Quiz / study flow
+        - State selection / representatives
+        - Accessibility
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- Thanks for contributing! Please fill out this template. -->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Type of change
+
+- [ ] `feat:` new user-facing feature
+- [ ] `fix:` bug fix
+- [ ] `refactor:` no behavior change
+- [ ] `test:` tests only
+- [ ] `docs:` documentation only
+- [ ] `chore:` build / tooling / deps
+- [ ] `ci:` CI/CD workflow changes
+
+## Checklist
+
+- [ ] My branch follows the naming convention (`feat/...`, `fix/...`, etc.).
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) and are focused (one change per commit; functional vs. refactor separate).
+- [ ] Every commit includes the `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer.
+- [ ] Tests added or updated (`dotnet test`, `npm test`).
+- [ ] `npm run lint` passes.
+- [ ] `README.md` updated if behavior, setup, endpoints, or architecture changed.
+- [ ] `CONTEXT.md` updated to reflect the new project state.
+- [ ] For frontend changes: accessibility considered (WCAG 2.1 AA, keyboard nav, semantic HTML).
+- [ ] For API changes: `CancellationToken` plumbed through async calls; versioned route preserved.
+
+## Screenshots / recordings
+
+<!-- For UI changes, attach before/after images or a short recording. -->
+
+## Related issues
+
+<!-- Closes #123, Relates to #456 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/src/client"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "nuget"
+    directory: "/src/api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "nuget"
+    directory: "/tests/api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "tests"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          dotnet-quality: "preview"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via GitHub's private vulnerability reporting or by opening a private issue. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,12 +177,38 @@ Application Insights (free tier, 5 GB/mo ingest) provides production observabili
 3. Configure custom domain + TLS ingress
 4. Update README and CONTEXT.md
 
+**Phase 4 — Make Repository Public** (open-source release):
+
+Audit completed: no `.env` files, no hard-coded secrets, no connection strings, no API keys in source or config. `appsettings*.json` contain only logging config. CI/CD workflow uses `secrets.GITHUB_TOKEN` (auto-provided) — no custom secrets yet.
+
+Required before flipping visibility to public:
+
+1. **Add `LICENSE`** — MIT license (chosen: permissive, simple, compatible with dependencies).
+2. **Add `CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1 (GitHub standard).
+3. **Add `CONTRIBUTING.md`** — how to set up dev environment, run tests, commit conventions (Conventional Commits + Co-authored-by trailer), PR process.
+4. **Add `SECURITY.md`** — vulnerability reporting process (private security advisories via GitHub).
+5. **Add `.github/ISSUE_TEMPLATE/`** — `bug_report.md`, `feature_request.md`, and `config.yml`.
+6. **Add `.github/PULL_REQUEST_TEMPLATE.md`** — checklist (tests pass, docs updated, CONTEXT.md updated, single-purpose commit).
+7. **Add `.github/dependabot.yml`** — weekly updates for npm, nuget, github-actions, docker.
+8. **Update `README.md`** — add badges (CI status, license, GHCR image), attribution note for USCIS question content (public domain — U.S. federal government work, 17 U.S.C. § 105), link to LICENSE/CONTRIBUTING/SECURITY.
+9. **Verify git history** — run secret scan locally (e.g., `gitleaks detect`) to confirm no historical leaks before going public.
+10. **Enable GitHub repo settings** (post-flip):
+    - Secret scanning + push protection (free for public repos)
+    - Dependabot alerts + security updates
+    - Private vulnerability reporting
+    - Branch protection on `main` (require CI green, require PR review, no force push)
+    - (Optional) `CODEOWNERS` file for auto-review routing
+11. **Make GHCR package public** — after first public push, set the `naturalizationpuzzle` package visibility to public at `github.com/users/<owner>/packages/container/naturalizationpuzzle/settings`, otherwise `docker pull` will 404 for external users.
+12. **Flip repository visibility** to public (Settings → Danger Zone → Change visibility).
+13. Update README and CONTEXT.md.
+
 ## Next Steps
 
 1. ~~**Containerized local deployment** (Phase 1)~~ ✅ complete
 2. ~~**GitHub CI/CD** (Phase 2)~~ ✅ complete — App Insights SDK + GitHub Actions workflow
 3. **Azure Container Apps deployment** (Phase 3)
-4. Add dark mode support
-5. Add category-based filtering on the Study Page (API endpoint exists, not wired to UI)
-6. Add congressional district selector for multi-district states (currently shows all reps)
-7. Add tests for StudyPage keyword search feature
+4. **Make repository public** (Phase 4) — license, community health files, security hardening
+5. Add dark mode support
+6. Add category-based filtering on the Study Page (API endpoint exists, not wired to UI)
+7. Add congressional district selector for multi-district states (currently shows all reps)
+8. Add tests for StudyPage keyword search feature

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,11 @@ servers-start.bat     # uses servers.ps1
 **Backend (xUnit):**
 
 ```bash
-cd src/api
+# from repo root — discovers all test projects via the solution
 dotnet test
 ```
+
+The xUnit project lives in `tests/api/`; running `dotnet test` from `src/api/` would only target the API project and execute zero tests.
 
 **Frontend (Vitest):**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to NaturalizationPuzzle
+
+Thanks for your interest in contributing. This document explains how to set up the project, run tests, and submit changes.
+
+## Prerequisites
+
+- **.NET 10 SDK** (preview / RC). The API targets `net10.0`.
+- **Node.js 22.x** and npm.
+- **Git** with a configured user name and email.
+- Optional: Docker Desktop for container-based testing, PowerShell 7+ on non-Windows.
+
+## Repository layout
+
+```
+src/client   React 19 + Vite + TypeScript frontend (PWA)
+src/api      .NET 10 Minimal API + EF Core + SQLite
+tests/api    xUnit tests for the API
+tests/e2e    Playwright end-to-end tests
+```
+
+## Getting started
+
+```bash
+# Clone
+git clone https://github.com/henrik-me/NaturalizationPuzzle.git
+cd NaturalizationPuzzle
+
+# Backend
+cd src/api
+dotnet restore
+dotnet run            # starts API
+
+# Frontend (new terminal)
+cd src/client
+npm ci
+npm run dev           # starts Vite dev server
+```
+
+Or start both together on Windows:
+
+```
+servers-start.bat     # uses servers.ps1
+```
+
+## Running tests
+
+**Backend (xUnit):**
+
+```bash
+cd src/api
+dotnet test
+```
+
+**Frontend (Vitest):**
+
+```bash
+cd src/client
+npm test
+npm run lint
+```
+
+**End-to-end (Playwright):** Requires both servers running.
+
+```bash
+cd tests/e2e
+npx playwright install   # first time
+npx playwright test
+```
+
+## Container validation
+
+```
+container-test.ps1       # build, start, health check, smoke test, cleanup
+```
+
+## Coding conventions
+
+See `.github/copilot-instructions.md` for the full style guide. The key rules:
+
+- **TypeScript** strict mode, no `any`, named exports, explicit return types.
+- **C#** file-scoped namespaces, `record` for DTOs, nullable enabled, `CancellationToken` on all async methods, `Async` suffix.
+- **Async everywhere** — never `.Result` or `.Wait()`; use EF Core async variants.
+- **Dependency injection** — services, repositories, and `DbContext` registered in DI; use constructor injection.
+- **Errors** — client returns `ApiResult<T>` union types; API uses `ProblemDetails` via the global exception handler.
+- **Accessibility** — WCAG 2.1 AA; semantic HTML; `data-testid` selectors for E2E.
+
+## Commit conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) and enforces a **one-commit-per-change** rule. Keep functional changes and refactors in separate commits.
+
+Prefixes: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`, `ci:`.
+
+**Every commit must include the Copilot co-author trailer:**
+
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+## Pull request process
+
+1. Fork the repo and create a feature branch (`feat/short-description`).
+2. Make your change as a focused, single-purpose commit (or a small logical series).
+3. Run the full test suite locally (`dotnet test`, `npm test`, `npm run lint`).
+4. Update `README.md` if behavior, setup, endpoints, or architecture changed.
+5. Update `CONTEXT.md` to reflect the new state of the project.
+6. Open a PR. CI must pass. At least one approving review is required.
+
+The PR template has a checklist — please complete it.
+
+## Reporting issues
+
+Use the issue templates under **New issue** to file bugs or request features. For security vulnerabilities, see [SECURITY.md](./SECURITY.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 henrik-me
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # NaturalizationPuzzle
 
 [![CI/CD](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/ci-cd.yml)
+[![CodeQL](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/codeql.yml/badge.svg)](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/codeql.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![GHCR](https://img.shields.io/badge/container-ghcr.io-2088FF?logo=github)](https://github.com/henrik-me/NaturalizationPuzzle/pkgs/container/naturalizationpuzzle)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
+[![Node 22](https://img.shields.io/badge/Node-22-339933?logo=node.js)](https://nodejs.org/)
 
 A web-based study app for the **2025 USCIS Naturalization Civics Test** (128-question pool). Users select their U.S. state to get customized, state-specific answers (e.g., governor, senators). The app works **fully offline** after the first load.
 
@@ -534,3 +539,23 @@ requests
 - **65/20 rule**: applicants 65+ with 20+ years of residency study only 20 designated questions, are asked 10, and need 6 correct.
 - **Categories**: American Government (principles, system, rights/responsibilities), American History, and Integrated Civics (geography, symbols, holidays).
 - **State-specific answers**: governor, U.S. senators, U.S. House Representatives (all 435 by state/district), and capital are dynamically resolved based on the user's selected state.
+
+---
+
+## Content Attribution
+
+The 2025 USCIS civics test questions and official answers are works of the U.S. federal government and are in the public domain under [17 U.S.C. § 105](https://www.law.cornell.edu/uscode/text/17/105). Source: [USCIS Citizenship Resource Center](https://www.uscis.gov/citizenship).
+
+State-level data (governors, senators) and U.S. House Representatives (119th Congress) are sourced from public government records.
+
+## Contributing
+
+Contributions are welcome. Please read:
+
+- [**CONTRIBUTING.md**](./CONTRIBUTING.md) — dev setup, test commands, coding conventions, commit discipline, PR process.
+- [**CODE_OF_CONDUCT.md**](./CODE_OF_CONDUCT.md) — the Contributor Covenant we follow.
+- [**SECURITY.md**](./SECURITY.md) — how to report a vulnerability privately.
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI/CD](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/ci-cd.yml)
 [![CodeQL](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/codeql.yml/badge.svg)](https://github.com/henrik-me/NaturalizationPuzzle/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
-[![GHCR](https://img.shields.io/badge/container-ghcr.io-2088FF?logo=github)](https://github.com/henrik-me/NaturalizationPuzzle/pkgs/container/naturalizationpuzzle)
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4?logo=dotnet)](https://dotnet.microsoft.com/)
 [![Node 22](https://img.shields.io/badge/Node-22-339933?logo=node.js)](https://nodejs.org/)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ Out of scope:
 
 ## Supported Versions
 
-Only the latest commit on the `main` branch is supported. Fixes are applied there and released as new container images.
+Only the latest commit on the default branch (`master`) is supported. Fixes are applied there and released as new container images.
 
 ## Data handling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in NaturalizationPuzzle, please report it privately. **Do not open a public issue.**
+
+Use GitHub's **Private Vulnerability Reporting**:
+
+1. Go to the repository's [Security tab](https://github.com/henrik-me/NaturalizationPuzzle/security).
+2. Click **Report a vulnerability**.
+3. Fill out the form with a clear description, reproduction steps, and the impact you expect.
+
+You should receive an acknowledgement within a few days. We will work with you to understand the issue, develop a fix, and coordinate disclosure.
+
+## Scope
+
+In scope:
+
+- The .NET API (`src/api/`) and its endpoints.
+- The React PWA (`src/client/`), including the service worker and offline cache.
+- The Docker image published to GHCR.
+- The GitHub Actions CI/CD workflow.
+
+Out of scope:
+
+- Denial-of-service via traffic volume against any public deployment.
+- Vulnerabilities in third-party dependencies that have already been disclosed upstream — please report those to the relevant project.
+- Social engineering of maintainers.
+
+## Supported Versions
+
+Only the latest commit on the `main` branch is supported. Fixes are applied there and released as new container images.
+
+## Data handling
+
+This project stores no personal data server-side. All user preferences (selected state, study progress, quiz history) live exclusively in the browser's `localStorage`. The backend is a read-only source of civics question data.


### PR DESCRIPTION
## Summary

Phase 4 prep: make everything ready to flip the repository to public. This PR is additive only — no behavior changes, no source code touched.

## What's included

**Community health & legal**
- `LICENSE` — MIT, copyright `henrik-me` 2025.
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1.
- `CONTRIBUTING.md` — dev setup, tests, Conventional Commits, Co-authored-by trailer, PR process.
- `SECURITY.md` — private vulnerability reporting.

**GitHub templates & automation**
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` — structured forms; blank issues disabled.
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist.
- `.github/dependabot.yml` — weekly npm / nuget / github-actions / docker.
- `.github/CODEOWNERS` — default reviewer `@henrik-me`.

**CI hardening & code scanning**
- `.github/workflows/codeql.yml` — CodeQL for C# and JS/TS.
- `ci-cd.yml` — added `concurrency` group so superseded runs cancel (caps fork-PR spend post-flip).

**README polish**
- Badges: CodeQL, MIT, GHCR, .NET 10, Node 22.
- Content Attribution section (USCIS = public domain, 17 U.S.C. § 105).
- Links to LICENSE, CONTRIBUTING, SECURITY, COC.

**Context**
- `CONTEXT.md` — Phase 4 scope added.

## Not in this PR (manual post-merge clicks)

These require Settings UI actions, not code:

1. Flip repo visibility to Public.
2. Set GHCR package `naturalizationpuzzle` visibility to Public.
3. Enable Dependabot alerts + security updates, Secret scanning + push protection, Private vulnerability reporting.
4. Settings → Actions → General: require approval for all outside-collaborator fork PR workflows; default `GITHUB_TOKEN` → read-only; disable "Actions can create/approve PRs".
5. Branch protection ruleset on `main` (require PR + 1 approval + Build & Test + CodeQL + conversation resolution + linear history; block force push/delete; admin bypass allowed).
6. Tag protection ruleset for `v*` / `release-*` (admins only).
7. Repo description + topics; enable/disable Discussions/Wiki/Projects.

I'll document the exact click-paths in the next message / as a follow-up comment.

## Verification

- `gitleaks detect` on full history → clean (exit 0).
- 12 focused commits, each with the mandated `Co-authored-by: Copilot` trailer.
