### PR TITLE
chore(deps): bump 5 GitHub Actions (checkout, setup-dotnet, docker/*)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -172,7 +172,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Azure login (OIDC)
         uses: azure/login@v2
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Azure login (OIDC)
         uses: azure/login@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         if: matrix.language == 'csharp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"


### PR DESCRIPTION
Batch-bumps 5 GitHub Actions via cherry-picks from Dependabot PRs #7, #8, #9, #10, #11.

## Bumps
- `actions/checkout` 4 → 6 (#10)
- `actions/setup-dotnet` 4 → 5 (#8)
- `docker/login-action` 3 → 4 (#9)
- `docker/metadata-action` 5 → 6 (#11)
- `docker/build-push-action` 6 → 7 (#7)

## Why batched
These 5 actions all co-locate in `.github/workflows/ci-cd.yml` and `codeql.yml`. Batching gives one reviewable diff and one CI validation.

## Validation
Three of these bumps touch jobs that are guarded by `if: github.event_name == 'push'` (`docker-build-push`, `image-smoke-test`) or `github.ref == 'refs/heads/main'` (`deploy-plan`, `deploy-apply`). PR CI alone cannot exercise them.

To validate, the branch was temporarily added to `on.push.branches`, pushed, then the temp commit was dropped after the run completed green. Full push-path run: https://github.com/henrik-me/NaturalizationPuzzle/actions/runs/24751244778

Results:
- Build & Test ✅
- Docker Build & Push ✅ (image pushed to GHCR with branch tag)
- Image Smoke Test ✅ (container ran, `/health` probed)
- Deploy Plan / Deploy Apply: skipped (ref != main) — expected

## Not re-executed
Deploy jobs were not exercised because they are `main`-gated. Only bump touching those jobs is `actions/checkout@v6`, whose v4→v6 deltas (credential storage relocation, newer runner requirements) do not affect our deploy step pattern (checkout → read `infra/` → `az` CLI; no authenticated git).

## Scope
Closes #7, closes #8, closes #9, closes #10, closes #11.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
