### PR TITLE
chore(deps): bump .NET test stack + EF Core 10.0.7 (PRs #21, #23)

### DIFF
--- a/src/api/NaturalizationPuzzle.Api.csproj
+++ b/src/api/NaturalizationPuzzle.Api.csproj
@@ -8,12 +8,12 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.1.25451.107" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/tests/api/NaturalizationPuzzle.Api.Tests.csproj
+++ b/tests/api/NaturalizationPuzzle.Api.Tests.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/api/NaturalizationPuzzle.Api.Tests.csproj
+++ b/tests/api/NaturalizationPuzzle.Api.Tests.csproj
@@ -18,11 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit.v3" Version="3.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Batch-bumps .NET test stack + EF Core patches via cherry-picks of Dependabot PRs #21 + #23.

## Bumps (7 total)
**src/api** (3):
- `Microsoft.AspNetCore.OpenApi` 10.0.0-rc.1.25451.107 → 10.0.7 (RC → stable)
- `Microsoft.EntityFrameworkCore.Design` 10.0.3 → 10.0.7
- `Microsoft.EntityFrameworkCore.Sqlite` 10.0.3 → 10.0.7

**tests/api** (5 — coupled test stack):
- `Microsoft.AspNetCore.Mvc.Testing` 10.0.3 → 10.0.7
- `Microsoft.EntityFrameworkCore.InMemory` 10.0.3 → 10.0.7
- `Microsoft.NET.Test.Sdk` 17.14.1 → 18.4.0 (major)
- `xunit.v3` 3.0.0 → 3.2.2
- `xunit.runner.visualstudio` 3.1.3 → 3.1.5

## Why batched
PR #21 and PR #23 both touch `tests/api/*.csproj`; the test stack (`Test.Sdk` + `xunit*`) should be bumped together, not split across merges.

## Validation
Local: `dotnet restore` / `dotnet build` clean / `dotnet test` — all 31 tests pass (VSTest 18.0.1, xUnit v3 3.2.2).

Full push-path CI run (temp-trigger technique, branch added to `on.push.branches`, run completed, commit dropped):  
https://github.com/henrik-me/NaturalizationPuzzle/actions/runs/24751950181
- Build & Test ✅
- Docker Build & Push ✅ (image pushed to GHCR)
- Image Smoke Test ✅ (container boots; `/health` probed — confirms OpenAPI RC→stable did not break startup)
- Deploy Plan / Deploy Apply: skipped (ref != main) — expected

## Notes
- `Microsoft.AspNetCore.OpenApi` RC → stable is the most material change; smoke test covers app boot. Schema-shape changes (if any) have no internal consumer.
- Pre-existing `xUnit1051` analyzer warnings persist (not introduced here).
- Closes #21, closes #23. Will auto-close superseded PR #25 (strict subset of #21).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
