### PR TITLE
ci: skip CI/CD on docs-only pushes to prevent cancelling pending deploys

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,6 +3,19 @@ name: CI/CD
 on:
   push:
     branches: [main, master]
+    # Docs-only pushes must NOT trigger this workflow. The workflow's
+    # cancel-in-progress concurrency would otherwise abort an in-flight or
+    # approval-pending deploy. Listing paths-ignore here is safer than
+    # queueing, which could deploy stale bits later.
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/copilot-instructions.md'
+      - '.github/instructions/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.gitignore'
+      - '.editorconfig'
   pull_request:
     branches: [main, master]
   workflow_dispatch:


### PR DESCRIPTION
Fixes a real incident: a docs-only merge to `main` cancelled an approval-pending production deploy via the workflow's shared `cancel-in-progress` concurrency group.

## Approach
Add `paths-ignore` to the `push` trigger so docs-only pushes don't trigger the workflow at all. This avoids:
- cancelling pending/in-flight deploys (previous bug)
- queueing main runs (which could deploy stale bits later)

`cancel-in-progress: true` is preserved for code pushes — newer code still always supersedes older code.

## Scope
- `.github/workflows/ci-cd.yml` only
- `paths-ignore` applies only to `push`; `pull_request` still runs full CI, so required PR status checks remain enforced.
- Mixed docs+code pushes still trigger the workflow (GitHub semantics: paths-ignore only skips when **all** changed files match).

## Review
Reviewed locally with the GPT-5.4 `code-review` sub-agent before push (per repo Code Review policy). No blocking issues.