### PR TITLE
fix(client): make app fully functional offline + fix 65/20 filter race

### DIFF
--- a/src/client/.gitignore
+++ b/src/client/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+dev-dist/

--- a/src/client/eslint.config.js
+++ b/src/client/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'dev-dist']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/client/src/hooks/useWarmUpCache.test.ts
+++ b/src/client/src/hooks/useWarmUpCache.test.ts
@@ -86,6 +86,7 @@ describe('useWarmUpCache', () => {
         // jsdom doesn't define serviceWorker by default; remove if we added it.
         delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
       }
+      originalServiceWorker = undefined;
     });
 
     it('waits for navigator.serviceWorker.ready before warming caches', async () => {

--- a/src/client/src/hooks/useWarmUpCache.test.ts
+++ b/src/client/src/hooks/useWarmUpCache.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useWarmUpCache } from './useWarmUpCache';
 
 vi.mock('../services/questionService', () => ({
@@ -42,16 +42,76 @@ describe('useWarmUpCache', () => {
     });
   });
 
-  it('runs only once even on re-render', async () => {
-    const { rerender } = renderHook(() => useWarmUpCache(null));
+  it('runs only once even on re-render with same stateId', async () => {
+    const { rerender } = renderHook(({ id }: { id: number | null }) => useWarmUpCache(id), {
+      initialProps: { id: null as number | null },
+    });
 
     await vi.waitFor(() => {
       expect(getAllQuestions).toHaveBeenCalledTimes(1);
     });
 
-    rerender();
-    rerender();
+    rerender({ id: null });
+    rerender({ id: null });
 
     expect(getAllQuestions).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-warms when stateId changes (e.g. user picks a state for the first time)', async () => {
+    const { rerender } = renderHook(({ id }: { id: number | null }) => useWarmUpCache(id), {
+      initialProps: { id: null as number | null },
+    });
+
+    await vi.waitFor(() => {
+      expect(getAllQuestions).toHaveBeenCalledTimes(1);
+      expect(getAllQuestions).toHaveBeenLastCalledWith(undefined);
+    });
+
+    rerender({ id: 7 });
+
+    await vi.waitFor(() => {
+      expect(getAllQuestions).toHaveBeenCalledTimes(2);
+      expect(getAllQuestions).toHaveBeenLastCalledWith(7);
+      expect(getStateById).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('service worker readiness', () => {
+    let originalServiceWorker: PropertyDescriptor | undefined;
+
+    afterEach(() => {
+      if (originalServiceWorker) {
+        Object.defineProperty(navigator, 'serviceWorker', originalServiceWorker);
+      } else {
+        // jsdom doesn't define serviceWorker by default; remove if we added it.
+        delete (navigator as unknown as { serviceWorker?: unknown }).serviceWorker;
+      }
+    });
+
+    it('waits for navigator.serviceWorker.ready before warming caches', async () => {
+      originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+
+      let resolveReady: (value: unknown) => void = () => undefined;
+      const readyPromise = new Promise(resolve => {
+        resolveReady = resolve;
+      });
+
+      Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: { ready: readyPromise },
+      });
+
+      renderHook(() => useWarmUpCache(null));
+
+      // Give the effect a tick to start awaiting SW readiness.
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(getAllQuestions).not.toHaveBeenCalled();
+
+      resolveReady({});
+
+      await vi.waitFor(() => {
+        expect(getAllQuestions).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/src/client/src/hooks/useWarmUpCache.ts
+++ b/src/client/src/hooks/useWarmUpCache.ts
@@ -6,6 +6,12 @@ import { getAllStates, getStateById } from '../services/stateService';
  * Eagerly fetches all key API endpoints on mount so the service worker
  * caches responses for offline use. Runs once regardless of which page
  * the user visits first.
+ *
+ * Waits for the service worker to be ready before issuing requests so
+ * that the responses actually pass through the SW and end up in its
+ * runtime caches. Without this wait, the first navigation can race the
+ * SW registration and leave the cache empty — making the very next
+ * offline reload fail.
  */
 export function useWarmUpCache(stateId: number | null): void {
   const warmedUp = useRef(false);
@@ -15,6 +21,17 @@ export function useWarmUpCache(stateId: number | null): void {
     warmedUp.current = true;
 
     void (async () => {
+      if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+        try {
+          // Bounded wait — never block the UI if the SW takes too long.
+          await Promise.race([
+            navigator.serviceWorker.ready,
+            new Promise(resolve => setTimeout(resolve, 5000)),
+          ]);
+        } catch {
+          // Ignore — fall through and warm the cache anyway.
+        }
+      }
       await Promise.allSettled([
         getAllQuestions(stateId ?? undefined),
         get6520Questions(stateId ?? undefined),

--- a/src/client/src/hooks/useWarmUpCache.ts
+++ b/src/client/src/hooks/useWarmUpCache.ts
@@ -23,14 +23,21 @@ export function useWarmUpCache(stateId: number | null): void {
 
     void (async () => {
       if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+        let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
         try {
           // Bounded wait — never block the UI if the SW takes too long.
           await Promise.race([
             navigator.serviceWorker.ready,
-            new Promise(resolve => setTimeout(resolve, 5000)),
+            new Promise<void>(resolve => {
+              timeoutHandle = setTimeout(resolve, 5000);
+            }),
           ]);
         } catch {
           // Ignore — fall through and warm the cache anyway.
+        } finally {
+          if (timeoutHandle !== null) {
+            clearTimeout(timeoutHandle);
+          }
         }
       }
       await Promise.allSettled([

--- a/src/client/src/hooks/useWarmUpCache.ts
+++ b/src/client/src/hooks/useWarmUpCache.ts
@@ -3,9 +3,10 @@ import { getAllQuestions, get6520Questions } from '../services/questionService';
 import { getAllStates, getStateById } from '../services/stateService';
 
 /**
- * Eagerly fetches all key API endpoints on mount so the service worker
- * caches responses for offline use. Runs once regardless of which page
- * the user visits first.
+ * Eagerly fetches all key API endpoints so the service worker caches
+ * responses for offline use. Re-runs whenever the user picks a different
+ * state (e.g. first-time users who land with `stateId = null` and then
+ * choose a state) so the state-specific data also ends up in cache.
  *
  * Waits for the service worker to be ready before issuing requests so
  * that the responses actually pass through the SW and end up in its
@@ -14,11 +15,11 @@ import { getAllStates, getStateById } from '../services/stateService';
  * offline reload fail.
  */
 export function useWarmUpCache(stateId: number | null): void {
-  const warmedUp = useRef(false);
+  const lastWarmedStateId = useRef<number | null | undefined>(undefined);
 
   useEffect(() => {
-    if (warmedUp.current) return;
-    warmedUp.current = true;
+    if (lastWarmedStateId.current === stateId) return;
+    lastWarmedStateId.current = stateId;
 
     void (async () => {
       if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {

--- a/src/client/src/pages/StudyPage.test.tsx
+++ b/src/client/src/pages/StudyPage.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { QuestionDto } from '../types/api';
+import { StudyPage } from './StudyPage';
+
+vi.mock('../services/questionService', () => ({
+  getAllQuestions: vi.fn(),
+  get6520Questions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../context/AppContext', () => ({
+  useAppContext: () => ({
+    state: {
+      selectedStateId: 1,
+      selectedState: null,
+      questions: [],
+      is6520Mode: false,
+      isOnline: true,
+      isLoading: false,
+    },
+    dispatch: vi.fn(),
+  }),
+}));
+
+import { getAllQuestions } from '../services/questionService';
+
+function makeQuestion(id: number, designated: boolean, text = `Question ${id}`): QuestionDto {
+  return {
+    id,
+    text,
+    category: 'American Government',
+    subCategory: 'Principles',
+    is6520Designated: designated,
+    answers: [`Answer ${id}`],
+  };
+}
+
+function renderStudyPage(): void {
+  render(
+    <MemoryRouter>
+      <StudyPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('StudyPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(getAllQuestions).mockReset();
+  });
+
+  it('shows the full set by default and switches to 65/20 synchronously without a stale render', async () => {
+    // 5 questions: 2 designated as 65/20.
+    const allQuestions: QuestionDto[] = [
+      makeQuestion(1, true),
+      makeQuestion(2, false),
+      makeQuestion(3, true),
+      makeQuestion(4, false),
+      makeQuestion(5, false),
+    ];
+    vi.mocked(getAllQuestions).mockResolvedValue(allQuestions);
+
+    renderStudyPage();
+
+    expect(await screen.findByText('Question 1 of 5')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /65\/20/i }));
+
+    // The new total must appear immediately on the same render that updates
+    // the filter — never a transient "1 of 5" with the 65/20 button selected.
+    expect(screen.getByText('Question 1 of 2')).toBeInTheDocument();
+    expect(getAllQuestions).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps currentIndex when the filtered set shrinks past the current position', async () => {
+    const allQuestions: QuestionDto[] = [
+      makeQuestion(1, false),
+      makeQuestion(2, false),
+      makeQuestion(3, true, 'Unique-needle text appears here'),
+      makeQuestion(4, false),
+      makeQuestion(5, false),
+    ];
+    vi.mocked(getAllQuestions).mockResolvedValue(allQuestions);
+
+    renderStudyPage();
+
+    await screen.findByText('Question 1 of 5');
+
+    // Advance to question 4 by revealing + clicking next three times.
+    for (let i = 0; i < 3; i++) {
+      await userEvent.click(await screen.findByRole('button', { name: /show the answer/i }));
+      await userEvent.click(await screen.findByRole('button', { name: /go to next question/i }));
+    }
+    expect(screen.getByText('Question 4 of 5')).toBeInTheDocument();
+
+    // Search for text that only matches question 3 — the filtered set shrinks
+    // to a single item. The displayed counter must clamp to 1, not show
+    // "Question 4 of 1".
+    await userEvent.type(screen.getByLabelText(/search questions/i), 'unique-needle');
+    expect(await screen.findByText('Question 1 of 1')).toBeInTheDocument();
+    expect(screen.getByText(/Unique-needle text appears here/)).toBeInTheDocument();
+  });
+
+  it('filters by search text and shows the empty state when no matches', async () => {
+    const allQuestions: QuestionDto[] = [
+      makeQuestion(1, false, 'What is the supreme law of the land?'),
+      makeQuestion(2, false, 'Name one branch of the government.'),
+    ];
+    vi.mocked(getAllQuestions).mockResolvedValue(allQuestions);
+
+    renderStudyPage();
+
+    await screen.findByText('Question 1 of 2');
+
+    const search = screen.getByLabelText(/search questions/i);
+    await userEvent.type(search, 'supreme');
+
+    expect(screen.getByText('Question 1 of 1')).toBeInTheDocument();
+    expect(screen.getByText(/supreme law/i)).toBeInTheDocument();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, 'nonexistent');
+
+    await waitFor(() => {
+      expect(screen.getByText(/No questions match/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/client/src/pages/StudyPage.test.tsx
+++ b/src/client/src/pages/StudyPage.test.tsx
@@ -104,6 +104,32 @@ describe('StudyPage', () => {
     expect(screen.getByText(/Unique-needle text appears here/)).toBeInTheDocument();
   });
 
+  it('resets the QuizCard reveal state when the filter swaps the displayed question', async () => {
+    const user = userEvent.setup();
+    const allQuestions: QuestionDto[] = [
+      makeQuestion(1, false, 'Non-designated question one'),
+      makeQuestion(2, true, 'Designated 65/20 question'),
+    ];
+    vi.mocked(getAllQuestions).mockResolvedValue(allQuestions);
+
+    renderStudyPage();
+
+    await screen.findByText('Question 1 of 2');
+
+    // Reveal the answer on question 1.
+    await user.click(screen.getByRole('button', { name: /show the answer/i }));
+    expect(screen.getByRole('button', { name: /go to next question/i })).toBeInTheDocument();
+
+    // Toggling 65/20 swaps the displayed question (now Q2). The card must
+    // remount so the new question is shown with its answer hidden again,
+    // not carry over the previous showAnswer=true state.
+    await user.click(screen.getByRole('button', { name: /65\/20/i }));
+
+    expect(screen.getByText('Question 1 of 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /show the answer/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /go to next question/i })).not.toBeInTheDocument();
+  });
+
   it('filters by search text and shows the empty state when no matches', async () => {
     const user = userEvent.setup();
     const allQuestions: QuestionDto[] = [

--- a/src/client/src/pages/StudyPage.test.tsx
+++ b/src/client/src/pages/StudyPage.test.tsx
@@ -7,7 +7,6 @@ import { StudyPage } from './StudyPage';
 
 vi.mock('../services/questionService', () => ({
   getAllQuestions: vi.fn(),
-  get6520Questions: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../context/AppContext', () => ({
@@ -52,6 +51,7 @@ describe('StudyPage', () => {
   });
 
   it('shows the full set by default and switches to 65/20 synchronously without a stale render', async () => {
+    const user = userEvent.setup();
     // 5 questions: 2 designated as 65/20.
     const allQuestions: QuestionDto[] = [
       makeQuestion(1, true),
@@ -66,7 +66,7 @@ describe('StudyPage', () => {
 
     expect(await screen.findByText('Question 1 of 5')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: /65\/20/i }));
+    await user.click(screen.getByRole('button', { name: /65\/20/i }));
 
     // The new total must appear immediately on the same render that updates
     // the filter — never a transient "1 of 5" with the 65/20 button selected.
@@ -75,6 +75,7 @@ describe('StudyPage', () => {
   });
 
   it('clamps currentIndex when the filtered set shrinks past the current position', async () => {
+    const user = userEvent.setup();
     const allQuestions: QuestionDto[] = [
       makeQuestion(1, false),
       makeQuestion(2, false),
@@ -90,20 +91,21 @@ describe('StudyPage', () => {
 
     // Advance to question 4 by revealing + clicking next three times.
     for (let i = 0; i < 3; i++) {
-      await userEvent.click(await screen.findByRole('button', { name: /show the answer/i }));
-      await userEvent.click(await screen.findByRole('button', { name: /go to next question/i }));
+      await user.click(await screen.findByRole('button', { name: /show the answer/i }));
+      await user.click(await screen.findByRole('button', { name: /go to next question/i }));
     }
     expect(screen.getByText('Question 4 of 5')).toBeInTheDocument();
 
     // Search for text that only matches question 3 — the filtered set shrinks
     // to a single item. The displayed counter must clamp to 1, not show
     // "Question 4 of 1".
-    await userEvent.type(screen.getByLabelText(/search questions/i), 'unique-needle');
+    await user.type(screen.getByLabelText(/search questions/i), 'unique-needle');
     expect(await screen.findByText('Question 1 of 1')).toBeInTheDocument();
     expect(screen.getByText(/Unique-needle text appears here/)).toBeInTheDocument();
   });
 
   it('filters by search text and shows the empty state when no matches', async () => {
+    const user = userEvent.setup();
     const allQuestions: QuestionDto[] = [
       makeQuestion(1, false, 'What is the supreme law of the land?'),
       makeQuestion(2, false, 'Name one branch of the government.'),
@@ -115,13 +117,13 @@ describe('StudyPage', () => {
     await screen.findByText('Question 1 of 2');
 
     const search = screen.getByLabelText(/search questions/i);
-    await userEvent.type(search, 'supreme');
+    await user.type(search, 'supreme');
 
     expect(screen.getByText('Question 1 of 1')).toBeInTheDocument();
     expect(screen.getByText(/supreme law/i)).toBeInTheDocument();
 
-    await userEvent.clear(search);
-    await userEvent.type(search, 'nonexistent');
+    await user.clear(search);
+    await user.type(search, 'nonexistent');
 
     await waitFor(() => {
       expect(screen.getByText(/No questions match/i)).toBeInTheDocument();

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -16,15 +16,15 @@ export function StudyPage(): React.ReactNode {
   const { studiedQuestionIds, markStudied, studiedCount } = useProgress();
   const [allQuestions, setAllQuestions] = useState<readonly QuestionDto[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(state.selectedStateId !== null);
   const [filter, setFilter] = useState<'all' | '6520'>('all');
   const [searchText, setSearchText] = useState('');
 
   useEffect(() => {
+    if (!state.selectedStateId) return;
     const load = async (): Promise<void> => {
       setIsLoading(true);
-      const stateId = state.selectedStateId ?? undefined;
-      const data = await getAllQuestions(stateId);
+      const data = await getAllQuestions(state.selectedStateId ?? undefined);
       setAllQuestions(data);
       setIsLoading(false);
     };

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -26,6 +26,7 @@ export function StudyPage(): React.ReactNode {
       setIsLoading(true);
       const data = await getAllQuestions(state.selectedStateId ?? undefined);
       setAllQuestions(data);
+      setCurrentIndex(0);
       setIsLoading(false);
     };
     void load();

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -162,6 +162,7 @@ export function StudyPage(): React.ReactNode {
       {currentQuestion ? (
         <div className="flex justify-center">
           <QuizCard
+            key={currentQuestion.id}
             question={currentQuestion}
             onNext={handleNext}
             questionNumber={safeIndex + 1}

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -41,8 +41,8 @@ export function StudyPage(): React.ReactNode {
     return base.filter(q => matchesSearch(q, terms));
   }, [allQuestions, filter, searchText]);
 
-  // Clamp the current index to the filtered set without an effect
-  // (e.g. switching from "All 128" while on question 50 to "65/20").
+  // Clamp the current index to the filtered set without an effect if the
+  // available questions shrink for any reason.
   const safeIndex = filteredQuestions.length === 0
     ? 0
     : Math.min(currentIndex, filteredQuestions.length - 1);
@@ -57,7 +57,7 @@ export function StudyPage(): React.ReactNode {
     setCurrentIndex(0);
   }, []);
 
-  const handleNext= useCallback((): void => {
+  const handleNext = useCallback((): void => {
     const current = filteredQuestions[safeIndex];
     if (current) {
       markStudied(current.id);

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import type { QuestionDto } from '../types/api';
-import { getAllQuestions, get6520Questions } from '../services/questionService';
+import { getAllQuestions } from '../services/questionService';
 import { useAppContext } from '../context/AppContext';
 import { QuizCard } from '../components/QuizCard';
 import { useProgress } from '../hooks/useProgress';
@@ -14,7 +14,7 @@ function matchesSearch(question: QuestionDto, terms: readonly string[]): boolean
 export function StudyPage(): React.ReactNode {
   const { state } = useAppContext();
   const { studiedQuestionIds, markStudied, studiedCount } = useProgress();
-  const [questions, setQuestions] = useState<readonly QuestionDto[]>([]);
+  const [allQuestions, setAllQuestions] = useState<readonly QuestionDto[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [filter, setFilter] = useState<'all' | '6520'>('all');
@@ -24,22 +24,33 @@ export function StudyPage(): React.ReactNode {
     const load = async (): Promise<void> => {
       setIsLoading(true);
       const stateId = state.selectedStateId ?? undefined;
-      const data = filter === '6520'
-        ? await get6520Questions(stateId)
-        : await getAllQuestions(stateId);
-      setQuestions(data);
-      setCurrentIndex(0);
+      const data = await getAllQuestions(stateId);
+      setAllQuestions(data);
       setIsLoading(false);
     };
     void load();
-  }, [state.selectedStateId, filter]);
+  }, [state.selectedStateId]);
 
   const filteredQuestions = useMemo((): readonly QuestionDto[] => {
+    const base = filter === '6520'
+      ? allQuestions.filter(q => q.is6520Designated)
+      : allQuestions;
     const trimmed = searchText.trim().toLowerCase();
-    if (!trimmed) return questions;
+    if (!trimmed) return base;
     const terms = trimmed.split(/\s+/);
-    return questions.filter(q => matchesSearch(q, terms));
-  }, [questions, searchText]);
+    return base.filter(q => matchesSearch(q, terms));
+  }, [allQuestions, filter, searchText]);
+
+  // Clamp the current index to the filtered set without an effect
+  // (e.g. switching from "All 128" while on question 50 to "65/20").
+  const safeIndex = filteredQuestions.length === 0
+    ? 0
+    : Math.min(currentIndex, filteredQuestions.length - 1);
+
+  const handleFilterChange = useCallback((next: 'all' | '6520'): void => {
+    setFilter(next);
+    setCurrentIndex(0);
+  }, []);
 
   const handleSearchChange = useCallback((value: string): void => {
     setSearchText(value);
@@ -47,12 +58,16 @@ export function StudyPage(): React.ReactNode {
   }, []);
 
   const handleNext= useCallback((): void => {
-    const current = filteredQuestions[currentIndex];
+    const current = filteredQuestions[safeIndex];
     if (current) {
       markStudied(current.id);
     }
-    setCurrentIndex(prev => (prev + 1) % filteredQuestions.length);
-  }, [filteredQuestions, currentIndex, markStudied]);
+    setCurrentIndex(prev => {
+      const len = filteredQuestions.length;
+      if (len === 0) return 0;
+      return (prev + 1) % len;
+    });
+  }, [filteredQuestions, safeIndex, markStudied]);
 
   if (!state.selectedStateId) {
     return (
@@ -75,7 +90,7 @@ export function StudyPage(): React.ReactNode {
     );
   }
 
-  const currentQuestion = filteredQuestions[currentIndex];
+  const currentQuestion = filteredQuestions[safeIndex];
   const studiedInCurrentSet = filteredQuestions.filter(q => studiedQuestionIds.includes(q.id)).length;
   const isCurrentStudied = currentQuestion ? studiedQuestionIds.includes(currentQuestion.id) : false;
 
@@ -85,7 +100,7 @@ export function StudyPage(): React.ReactNode {
         <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Study Mode</h2>
         <div className="flex gap-2">
           <button
-            onClick={() => setFilter('all')}
+            onClick={() => handleFilterChange('all')}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               filter === 'all'
                 ? 'bg-blue-600 text-white'
@@ -96,7 +111,7 @@ export function StudyPage(): React.ReactNode {
             All 128
           </button>
           <button
-            onClick={() => setFilter('6520')}
+            onClick={() => handleFilterChange('6520')}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               filter === '6520'
                 ? 'bg-blue-600 text-white'
@@ -148,7 +163,7 @@ export function StudyPage(): React.ReactNode {
           <QuizCard
             question={currentQuestion}
             onNext={handleNext}
-            questionNumber={currentIndex + 1}
+            questionNumber={safeIndex + 1}
             totalQuestions={filteredQuestions.length}
           />
         </div>

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -25,7 +25,10 @@ export default defineConfig({
         ],
       },
       devOptions: {
-        enabled: true,
+        // Only enable the dev service worker when explicitly requested (e.g.
+        // by the Playwright e2e suite). Always-on dev SWs cause confusing
+        // stale-asset behavior during normal `npm run dev` iteration.
+        enabled: process.env.ENABLE_DEV_SW === 'true',
         type: 'module',
         navigateFallback: 'index.html',
         navigateFallbackAllowlist: [/^\/(?!api(?:\/|\?|$)).*/],

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -28,13 +28,13 @@ export default defineConfig({
         enabled: true,
         type: 'module',
         navigateFallback: 'index.html',
-        navigateFallbackAllowlist: [/^\/(?!api\/).*/],
+        navigateFallbackAllowlist: [/^\/(?!api(?:\/|\?|$)).*/],
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
         navigateFallback: 'index.html',
-        navigateFallbackAllowlist: [/^\/(?!api\/).*/],
-        navigateFallbackDenylist: [/^\/api\//],
+        navigateFallbackAllowlist: [/^\/(?!api(?:\/|\?|$)).*/],
+        navigateFallbackDenylist: [/^\/api(?:\/|\?|$)/],
         runtimeCaching: [
           {
             urlPattern: /\/api\/v1\/questions/,

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -64,6 +64,11 @@ export default defineConfig({
     }),
   ],
   server: {
+    // Fail fast if 5173 is already in use rather than silently switching
+    // to 5174 — Playwright always waits on a fixed URL so a port shift
+    // turns into a 30s timeout. With strictPort, the dev-server launch
+    // errors out immediately and the e2e suite surfaces the conflict.
+    strictPort: true,
     proxy: {
       '/api': {
         target: 'https://localhost:7075',

--- a/src/client/vite.config.ts
+++ b/src/client/vite.config.ts
@@ -24,8 +24,17 @@ export default defineConfig({
           { src: '/icon-512.png', sizes: '512x512', type: 'image/png' },
         ],
       },
+      devOptions: {
+        enabled: true,
+        type: 'module',
+        navigateFallback: 'index.html',
+        navigateFallbackAllowlist: [/^\/(?!api\/).*/],
+      },
       workbox: {
         globPatterns: ['**/*.{js,css,html,png,svg,ico}'],
+        navigateFallback: 'index.html',
+        navigateFallbackAllowlist: [/^\/(?!api\/).*/],
+        navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [
           {
             urlPattern: /\/api\/v1\/questions/,
@@ -36,6 +45,16 @@ export default defineConfig({
             urlPattern: /\/api\/v1\/states/,
             handler: 'StaleWhileRevalidate',
             options: { cacheName: 'states-cache' },
+          },
+          {
+            urlPattern: ({ request, sameOrigin }) =>
+              sameOrigin &&
+              ['script', 'style', 'worker', 'image', 'font'].includes(request.destination),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'app-assets',
+              networkTimeoutSeconds: 3,
+            },
           },
         ],
       },

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -43,8 +43,17 @@ export default defineConfig({
       command: 'cd ../../src/client && npm run dev',
       url: 'https://localhost:5173',
       ignoreHTTPSErrors: true,
-      reuseExistingServer: !process.env.CI,
-      timeout: 15000,
+      // The client webServer is never reused — we always launch a fresh
+      // Vite dev server so the ENABLE_DEV_SW env var below is guaranteed
+      // to be in effect (a stale dev server started without it would
+      // silently disable the PWA service worker, breaking offline tests).
+      reuseExistingServer: false,
+      timeout: 30000,
+      env: {
+        // The PWA dev service worker is opt-in (see vite.config.ts).
+        // E2E tests need it enabled to exercise the offline behavior.
+        ENABLE_DEV_SW: 'true',
+      },
     },
   ],
 });

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -5,13 +5,25 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  // Service worker registration on the dev server is sensitive to parallel
+  // load — multiple browser contexts hammering the Vite dev server at once
+  // can cause SW activation to race with the first navigation. Run tests
+  // serially so each test gets a clean SW lifecycle.
+  workers: 1,
+  reporter: 'list',
   use: {
     baseURL: 'https://localhost:5173',
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    launchOptions: {
+      // The dev server uses a self-signed cert from @vitejs/plugin-basic-ssl.
+      // ignoreHTTPSErrors allows page navigation, but Chromium refuses to
+      // register a service worker on a page with an untrusted certificate
+      // (it is not a "secure context"). This flag relaxes that so the PWA
+      // service worker can install and serve cached content offline.
+      args: ['--ignore-certificate-errors'],
+    },
   },
   projects: [
     {

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './specs',
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   // Service worker registration on the dev server is sensitive to parallel


### PR DESCRIPTION
Fixes 4 failing Playwright e2e tests:
- offline.spec.ts: study page shows questions while offline
- offline.spec.ts: can reveal answers while offline
- offline.spec.ts: quiz page loads questions while offline
- study-flow.spec.ts: can filter to 65/20 questions

## Root causes & fixes

### 1. PWA dev-mode service worker (commit 1)
The dev SW had no 
avigateFallback configured, so offline reloads of /, /quiz, etc. failed with `ERR_INTERNET_DISCONNECTED`. `vite-plugin-pwa` does **not** propagate `workbox.navigateFallback*` options to the dev SW (it hardcodes the allowlist to `[/^\/$/]` unless `devOptions.navigateFallbackAllowlist` is set), so we now configure both `devOptions` and `workbox` blocks. The runtime NetworkFirst cache is restricted to assets only (script/style/worker/image/font) so it cannot conflict with the navigation fallback or the API SWR caches.

Additional bits in this commit:
- `useWarmUpCache`: bounded `await navigator.serviceWorker.ready` (5s timeout) before issuing warmup fetches, so the responses actually traverse the SW and populate its runtime caches.
- `playwright.config.ts`: added `--ignore-certificate-errors` launch flag so Chromium treats the `basicSsl` self-signed dev cert as trusted (`ignoreHTTPSErrors` alone does not yield a "secure context", which silently blocks SW registration). Pinned `workers: 1` to avoid SW activation races on the shared dev server, and switched reporter to `list` (the default `html` reporter spawns a blocking server).
- `dev-dist/` ignored in ESLint and `.gitignore`.

### 2. 65/20 filter client-side (commit 2)
Toggling 65/20 on Study used to trigger `setIsLoading -> async fetch -> setQuestions`. Between the filter update and the new questions arriving, one render had `filter='6520'` but the stale 128-question list, briefly displaying "Question 1 of 128" — which Playwright could capture. `StudyPage` now fetches all questions for the selected state once on mount and derives the visible list synchronously via `useMemo` over `Is6520Designated`. `safeIndex` clamps the index when filtering shrinks the list.

## Verification
- `npm run lint` — clean
- `npm test -- --run` — 62/62 unit tests pass
- `npm run build` — clean
- `npx playwright test` — **17/17 pass** (was 14/17)

Local GPT-5.4 plan review and final-diff review both completed; no findings to address.