### PR TITLE
feat: add LogSanitizer to prevent log forging (CWE-117)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -358,6 +358,18 @@ Maintain the `README.md` file in the repository root. The README is the public-f
 - Use `FluentValidation` or `DataAnnotations` for request validation. Return `Results.ValidationProblem()` with field-level error details.
 - Log errors with structured logging (`ILogger<T>`) including correlation IDs for traceability.
 
+### Logging — Sanitize User-Controlled Input (CWE-117)
+
+Log forging (CWE-117) happens when attacker-controlled CR/LF or other control characters end up in a log entry, letting an attacker forge fake log lines, hide activity, or inject ANSI terminal escapes. Always assume **anything derived from a request is hostile**: paths, query strings, route values, header values, request bodies, and any string built from them — including exception messages that quote user input.
+
+**Rules:**
+
+- **Never log a user-controlled string directly.** Wrap it with `LogSanitizer.Clean(value)` or, for ASP.NET types, the `.ForLog()` extension (`PathString`, `QueryString`, `string?`). Both live in `NaturalizationPuzzle.Api.Logging`. They strip CR/LF, NEL/LS/PS, other C0/C1 control characters, and DEL; preserve TAB; truncate to a fixed cap with an explicit truncation marker.
+- **Always use structured-log placeholders** (`{Foo}`) and pass the value as an argument. Never interpolate or concatenate user input into the message template; never use user input as the format string itself.
+- **Stack traces use `LogSanitizer.Clean(value, LogSanitizer.MaxStackTraceLength)`** (32 KB cap) — the default 4 KB cap is for short scalar fields and would truncate real traces.
+- **Raw `Exception` is opt-in.** `GlobalExceptionHandler` defaults to logging sanitized `ExceptionType` / `ExceptionMessage` / `ExceptionStackTrace` fields and does **not** pass the raw `Exception` to the logger. Set `Logging:Exceptions:IncludeRawException = true` (config or env var) to restore raw-exception logging for debugging — this re-enables first-class structured exception telemetry on OpenTelemetry / Application Insights at the cost of plaintext-sink CWE-117 safety.
+- **Tests for new logging sites** that emit user-controlled values must include at least one assertion that the rendered log message contains no `\r` / `\n` when the input contains them.
+
 ### API Versioning
 
 - Use **URL path versioning**: `/api/v1/questions`, `/api/v2/questions`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,10 @@ Full-stack application scaffolded and building. Backend API is functional with s
 - React ErrorBoundary wrapping Routes with user-friendly fallback
 - .NET GlobalExceptionHandler middleware returning ProblemDetails (RFC 9457)
   with correlation IDs and structured logging
+- `LogSanitizer` (`src/api/Logging/`) sanitizes user-controlled values to prevent
+  log forging (CWE-117). GlobalExceptionHandler logs sanitized exception fields by
+  default; set `Logging:Exceptions:IncludeRawException=true` to restore raw
+  `Exception` logging (richer OTel/AppInsights telemetry, used for debugging).
 
 ## Decisions Made
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Navigate to **https://localhost:5173** in your browser. Both servers must be run
 src/api/
 ├── Program.cs              # App bootstrap, DI, middleware pipeline
 ├── Data/                   # EF Core DbContext & seed data
+├── Logging/                # LogSanitizer (CWE-117 defense) & options
 ├── Models/                 # Entity models & record DTOs
 ├── Services/               # Business logic (Question, State, Quiz)
 ├── Endpoints/              # Minimal API route definitions
@@ -141,7 +142,8 @@ src/api/
 
 - **DI container** registers `QuestionService`, `StateService`, and `QuizService` as scoped.
 - **EF Core + SQLite** with all 128 USCIS civics questions and 435 U.S. House Representatives (119th Congress) seeded on startup.
-- **Global exception handler** returns RFC 9457 `ProblemDetails` with correlation IDs.
+- **Global exception handler** returns RFC 9457 `ProblemDetails` with correlation IDs. By default it logs sanitized exception fields (type, message, stack trace) without the raw `Exception` object to prevent log forging (CWE-117). Set `Logging:Exceptions:IncludeRawException = true` to log the raw `Exception` for full structured exception telemetry on OpenTelemetry / Application Insights when debugging.
+- **`LogSanitizer`** (`NaturalizationPuzzle.Api.Logging`) strips control characters (CR, LF, NEL, LS, PS, other C0/C1, DEL) and truncates user-controlled values before they enter log entries. Use `LogSanitizer.Clean(...)` or the `.ForLog()` extension on every log site that touches request input.
 - **CORS** configured to allow the frontend origins (`https://localhost:5173` and `http://localhost:5173`).
 
 ### API Endpoints

--- a/src/api/Logging/ExceptionLoggingOptions.cs
+++ b/src/api/Logging/ExceptionLoggingOptions.cs
@@ -1,0 +1,25 @@
+namespace NaturalizationPuzzle.Api.Logging;
+
+/// <summary>
+/// Controls how unhandled exceptions are written to logs by
+/// <see cref="Middleware.GlobalExceptionHandler"/>.
+/// </summary>
+public sealed class ExceptionLoggingOptions
+{
+    public const string SectionName = "Logging:Exceptions";
+
+    /// <summary>
+    /// When <c>false</c> (default, production-safe), the global exception handler
+    /// logs the exception type, sanitized message, and sanitized stack trace as
+    /// separate structured fields, and does NOT pass the raw <see cref="System.Exception"/>
+    /// to the logger. This guarantees CWE-117 (log forging) safety on every log
+    /// sink, including plaintext console/file sinks, even if exception messages
+    /// contain attacker-controlled CR/LF or control characters.
+    ///
+    /// When <c>true</c> (debugging), the raw <see cref="System.Exception"/> is
+    /// passed to the logger, restoring first-class structured exception telemetry
+    /// for OpenTelemetry / Application Insights at the cost of plaintext-sink
+    /// log-forging safety. Use only for debugging, not in untrusted environments.
+    /// </summary>
+    public bool IncludeRawException { get; set; }
+}

--- a/src/api/Logging/LogSanitizer.cs
+++ b/src/api/Logging/LogSanitizer.cs
@@ -1,0 +1,82 @@
+namespace NaturalizationPuzzle.Api.Logging;
+
+/// <summary>
+/// Sanitizes user-controlled scalar values before they are embedded in log entries
+/// to prevent log forging (CWE-117). Strips line-breaking characters (CR, LF,
+/// NEL, LS, PS), other C0/C1 control characters, DEL, and truncates to a fixed
+/// maximum length. Intended for short user-controlled fields such as request paths,
+/// query strings, route values, and header values — not for stack traces or large
+/// payloads.
+/// </summary>
+internal static class LogSanitizer
+{
+    internal const int MaxLength = 4096;
+    internal const int MaxStackTraceLength = 32 * 1024;
+    private const char Replacement = '_';
+
+    public static string Clean(string? value) => Clean(value, MaxLength);
+
+    public static string Clean(string? value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        // Mandatory CR/LF removal first: CodeQL's cs/log-forging rule recognizes
+        // String.Replace of '\r'/'\n' as a sanitizer, so this must be present and
+        // visible at the top of the method even though the loop below would also
+        // catch them.
+        var safe = value.Replace('\r', Replacement).Replace('\n', Replacement);
+
+        if (NeedsControlCharStripping(safe))
+        {
+            safe = StripControlChars(safe);
+        }
+
+        if (safe.Length > maxLength)
+        {
+            safe = string.Concat(
+                safe.AsSpan(0, maxLength),
+                $"…[truncated:{value.Length}]");
+        }
+
+        return safe;
+    }
+
+    private static bool NeedsControlCharStripping(string value)
+    {
+        foreach (var c in value)
+        {
+            if (IsBanned(c))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string StripControlChars(string value)
+    {
+        return string.Create(value.Length, value, static (span, source) =>
+        {
+            for (var i = 0; i < source.Length; i++)
+            {
+                var c = source[i];
+                span[i] = IsBanned(c) ? Replacement : c;
+            }
+        });
+    }
+
+    private static bool IsBanned(char c)
+    {
+        // Preserve TAB; strip all other control characters (C0 + C1 + DEL via
+        // char.IsControl) plus the Unicode line/paragraph separators that some
+        // log viewers honor as line breaks.
+        if (c == '\t')
+        {
+            return false;
+        }
+        return char.IsControl(c) || c == '\u2028' || c == '\u2029';
+    }
+}

--- a/src/api/Logging/LogSanitizerExtensions.cs
+++ b/src/api/Logging/LogSanitizerExtensions.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+
+namespace NaturalizationPuzzle.Api.Logging;
+
+internal static class LogSanitizerExtensions
+{
+    public static string ForLog(this string? value) => LogSanitizer.Clean(value);
+
+    public static string ForLog(this PathString path) => LogSanitizer.Clean(path.Value);
+
+    public static string ForLog(this QueryString query) => LogSanitizer.Clean(query.Value);
+}

--- a/src/api/Middleware/GlobalExceptionHandler.cs
+++ b/src/api/Middleware/GlobalExceptionHandler.cs
@@ -1,22 +1,50 @@
 using System.Net;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NaturalizationPuzzle.Api.Logging;
 
 namespace NaturalizationPuzzle.Api.Middleware;
 
-public sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
+public sealed class GlobalExceptionHandler(
+    ILogger<GlobalExceptionHandler> logger,
+    IOptions<ExceptionLoggingOptions> options) : IExceptionHandler
 {
+    private readonly ExceptionLoggingOptions _options = options.Value;
+
     public async ValueTask<bool> TryHandleAsync(
         HttpContext httpContext,
         Exception exception,
         CancellationToken cancellationToken)
     {
         var correlationId = Guid.NewGuid().ToString();
+        var sanitizedPath = httpContext.Request.Path.ForLog();
 
-        logger.LogError(exception,
-            "Unhandled exception occurred. CorrelationId: {CorrelationId}, Path: {Path}",
-            correlationId,
-            httpContext.Request.Path);
+        if (_options.IncludeRawException)
+        {
+            // Debug-only path: hands the raw Exception object to the logger so
+            // OpenTelemetry / Application Insights can emit structured exception
+            // telemetry. Plaintext sinks may render exception.ToString() and
+            // expose unsanitized exception messages — accept that risk in
+            // exchange for full-fidelity debugging telemetry.
+            logger.LogError(exception,
+                "Unhandled exception occurred. CorrelationId: {CorrelationId}, Path: {Path}",
+                correlationId,
+                sanitizedPath);
+        }
+        else
+        {
+            // Production-safe path: log sanitized exception fields without
+            // passing the raw Exception object, guaranteeing CWE-117 safety on
+            // every sink at the cost of structured exception telemetry.
+            logger.LogError(
+                "Unhandled exception occurred. CorrelationId: {CorrelationId}, Path: {Path}, ExceptionType: {ExceptionType}, ExceptionMessage: {ExceptionMessage}, ExceptionStackTrace: {ExceptionStackTrace}",
+                correlationId,
+                sanitizedPath,
+                LogSanitizer.Clean(exception.GetType().FullName),
+                LogSanitizer.Clean(exception.Message),
+                LogSanitizer.Clean(exception.StackTrace, LogSanitizer.MaxStackTraceLength));
+        }
 
         var problemDetails = new ProblemDetails
         {

--- a/src/api/NaturalizationPuzzle.Api.csproj
+++ b/src/api/NaturalizationPuzzle.Api.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NaturalizationPuzzle.Api.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -2,6 +2,7 @@ using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 using NaturalizationPuzzle.Api.Data;
 using NaturalizationPuzzle.Api.Endpoints;
+using NaturalizationPuzzle.Api.Logging;
 using NaturalizationPuzzle.Api.Middleware;
 using NaturalizationPuzzle.Api.Services;
 
@@ -23,6 +24,8 @@ builder.Services.AddScoped<IRepresentativeService, RepresentativeService>();
 
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
+builder.Services.Configure<ExceptionLoggingOptions>(
+    builder.Configuration.GetSection(ExceptionLoggingOptions.SectionName));
 
 builder.Services.AddOpenApi();
 builder.Services.AddCors(options =>

--- a/src/api/appsettings.json
+++ b/src/api/appsettings.json
@@ -3,6 +3,9 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "Exceptions": {
+      "IncludeRawException": false
     }
   },
   "AllowedHosts": "*"

--- a/tests/api/Logging/LogSanitizerTests.cs
+++ b/tests/api/Logging/LogSanitizerTests.cs
@@ -1,0 +1,148 @@
+using NaturalizationPuzzle.Api.Logging;
+
+namespace NaturalizationPuzzle.Api.Tests.Logging;
+
+public sealed class LogSanitizerTests
+{
+    [Fact]
+    public void Clean_Null_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, LogSanitizer.Clean(null));
+    }
+
+    [Fact]
+    public void Clean_Empty_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, LogSanitizer.Clean(string.Empty));
+    }
+
+    [Fact]
+    public void Clean_PlainAscii_Unchanged()
+    {
+        const string input = "/api/v1/questions?state=CA";
+        Assert.Equal(input, LogSanitizer.Clean(input));
+    }
+
+    [Fact]
+    public void Clean_NonAsciiAndEmoji_Unchanged()
+    {
+        const string input = "Ümlauts and 🎉 emoji and 中文";
+        Assert.Equal(input, LogSanitizer.Clean(input));
+    }
+
+    [Fact]
+    public void Clean_PreservesTab()
+    {
+        Assert.Equal("a\tb", LogSanitizer.Clean("a\tb"));
+    }
+
+    [Theory]
+    [InlineData("a\rb", "a_b")]
+    [InlineData("a\nb", "a_b")]
+    [InlineData("a\r\nb", "a__b")]
+    [InlineData("a\u0085b", "a_b")]      // NEL
+    [InlineData("a\u2028b", "a_b")]      // LS
+    [InlineData("a\u2029b", "a_b")]      // PS
+    [InlineData("a\u0000b", "a_b")]      // NUL
+    [InlineData("a\u0007b", "a_b")]      // BEL
+    [InlineData("a\u0008b", "a_b")]      // BS
+    [InlineData("a\u001bb", "a_b")]      // ESC (ANSI escape vector)
+    [InlineData("a\u007fb", "a_b")]      // DEL
+    [InlineData("a\u0080b", "a_b")]      // C1 PAD
+    [InlineData("a\u009fb", "a_b")]      // C1 APC
+    public void Clean_ReplacesBannedChars(string input, string expected)
+    {
+        Assert.Equal(expected, LogSanitizer.Clean(input));
+    }
+
+    [Fact]
+    public void Clean_LogForgingAttack_NeutralizesNewlines()
+    {
+        const string input = "/q\r\n2026-01-01 ERROR Spoofed entry";
+        var actual = LogSanitizer.Clean(input);
+        Assert.DoesNotContain('\r', actual);
+        Assert.DoesNotContain('\n', actual);
+        Assert.Equal("/q__2026-01-01 ERROR Spoofed entry", actual);
+    }
+
+    [Fact]
+    public void Clean_AnsiEscapeInjection_NeutralizesEsc()
+    {
+        const string input = "user\u001b[31mFAKE-RED\u001b[0m";
+        var actual = LogSanitizer.Clean(input);
+        Assert.DoesNotContain('\u001b', actual);
+    }
+
+    [Fact]
+    public void Clean_AtMaxLength_NotTruncated()
+    {
+        var input = new string('a', LogSanitizer.MaxLength);
+        var actual = LogSanitizer.Clean(input);
+        Assert.Equal(input, actual);
+        Assert.DoesNotContain("truncated", actual);
+    }
+
+    [Fact]
+    public void Clean_OverMaxLength_TruncatesWithMarker()
+    {
+        var input = new string('a', LogSanitizer.MaxLength + 100);
+        var actual = LogSanitizer.Clean(input);
+
+        Assert.StartsWith(new string('a', LogSanitizer.MaxLength), actual);
+        Assert.Contains($"truncated:{input.Length}", actual);
+    }
+
+    [Fact]
+    public void Clean_OverMaxLengthWithControlChars_StripsThenTruncates()
+    {
+        var input = new string('a', LogSanitizer.MaxLength) + "\r\nEXTRA";
+        var actual = LogSanitizer.Clean(input);
+
+        Assert.DoesNotContain('\r', actual);
+        Assert.DoesNotContain('\n', actual);
+        Assert.Contains($"truncated:{input.Length}", actual);
+    }
+
+    [Fact]
+    public void Clean_IsIdempotent()
+    {
+        const string input = "/q\r\n\u001b[31mhi\t/end";
+        var once = LogSanitizer.Clean(input);
+        var twice = LogSanitizer.Clean(once);
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void ForLog_String_DelegatesToClean()
+    {
+        Assert.Equal("a_b", "a\nb".ForLog());
+    }
+
+    [Fact]
+    public void ForLog_PathString_DelegatesToClean()
+    {
+        var path = new Microsoft.AspNetCore.Http.PathString("/a\nb");
+        Assert.Equal("/a_b", path.ForLog());
+    }
+
+    [Fact]
+    public void ForLog_DefaultPathString_ReturnsEmpty()
+    {
+        var path = default(Microsoft.AspNetCore.Http.PathString);
+        Assert.Equal(string.Empty, path.ForLog());
+    }
+
+    [Fact]
+    public void ForLog_QueryString_DelegatesToClean()
+    {
+        var query = new Microsoft.AspNetCore.Http.QueryString("?x=1\n2");
+        Assert.Equal("?x=1_2", query.ForLog());
+    }
+
+    [Fact]
+    public void ForLog_DefaultQueryString_ReturnsEmpty()
+    {
+        var query = default(Microsoft.AspNetCore.Http.QueryString);
+        Assert.Equal(string.Empty, query.ForLog());
+    }
+}

--- a/tests/api/Middleware/GlobalExceptionHandlerTests.cs
+++ b/tests/api/Middleware/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,154 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NaturalizationPuzzle.Api.Logging;
+using NaturalizationPuzzle.Api.Middleware;
+
+namespace NaturalizationPuzzle.Api.Tests.Middleware;
+
+public sealed class GlobalExceptionHandlerTests
+{
+    [Fact]
+    public async Task TryHandleAsync_DefaultMode_LogsSanitizedFields_NoRawException_NoNewlines()
+    {
+        var logger = new RecordingLogger<GlobalExceptionHandler>();
+        var handler = CreateHandler(logger, includeRawException: false);
+        var ctx = NewContext("/api/v1/q\r\nFAKE LOG ENTRY");
+
+        var ex = MakeExceptionWithNewlinesInMessage();
+        var handled = await handler.TryHandleAsync(ctx, ex, CancellationToken.None);
+
+        Assert.True(handled);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Error, entry.Level);
+
+        // Default mode must NOT pass the raw Exception to the logger — sanitized
+        // exception fields are emitted as structured values instead.
+        Assert.Null(entry.Exception);
+
+        var rendered = entry.Formatter(entry.State, entry.Exception);
+        Assert.DoesNotContain('\r', rendered);
+        Assert.DoesNotContain('\n', rendered);
+        Assert.Contains("FAKE LOG ENTRY", rendered);
+        Assert.Contains("InvalidOperationException", rendered);
+        // Exception message contained CR/LF; rendered output must show sanitized form.
+        Assert.Contains("evil_message_part2", rendered);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_IncludeRawExceptionMode_PassesRawException()
+    {
+        var logger = new RecordingLogger<GlobalExceptionHandler>();
+        var handler = CreateHandler(logger, includeRawException: true);
+        var ctx = NewContext("/api/v1/x");
+
+        var ex = new InvalidOperationException("boom");
+        await handler.TryHandleAsync(ctx, ex, CancellationToken.None);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Same(ex, entry.Exception);
+        // Path is still sanitized even in the raw-exception mode.
+        var rendered = entry.Formatter(entry.State, entry.Exception);
+        Assert.Contains("/api/v1/x", rendered);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WritesProblemDetailsResponse()
+    {
+        var logger = new RecordingLogger<GlobalExceptionHandler>();
+        var handler = CreateHandler(logger, includeRawException: false);
+        var ctx = NewContext("/api/v1/x");
+
+        await handler.TryHandleAsync(ctx, new InvalidOperationException("boom"), CancellationToken.None);
+
+        Assert.Equal(StatusCodes.Status500InternalServerError, ctx.Response.StatusCode);
+        ctx.Response.Body.Position = 0;
+        using var reader = new StreamReader(ctx.Response.Body);
+        var body = await reader.ReadToEndAsync();
+        Assert.Contains("correlationId", body);
+    }
+
+    private static GlobalExceptionHandler CreateHandler(
+        ILogger<GlobalExceptionHandler> logger,
+        bool includeRawException)
+    {
+        var options = Options.Create(new ExceptionLoggingOptions
+        {
+            IncludeRawException = includeRawException,
+        });
+        return new GlobalExceptionHandler(logger, options);
+    }
+
+    private static DefaultHttpContext NewContext(string path)
+    {
+        var ctx = new DefaultHttpContext
+        {
+            Request = { Path = new PathString(path) },
+            Response = { Body = new MemoryStream() },
+        };
+        ctx.RequestServices = new MinimalServiceProvider();
+        return ctx;
+    }
+
+    private static InvalidOperationException MakeExceptionWithNewlinesInMessage()
+    {
+        // Throw and catch so the exception has a real stack trace.
+        try
+        {
+            throw new InvalidOperationException("evil_message_part1\r\nFORGED LOG\r\nevil_message_part2");
+        }
+        catch (InvalidOperationException caught)
+        {
+            return caught;
+        }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<LogEntry> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(
+                logLevel,
+                state!,
+                exception,
+                (s, e) => formatter((TState)s!, e)));
+        }
+
+        public sealed record LogEntry(
+            LogLevel Level,
+            object State,
+            Exception? Exception,
+            Func<object, Exception?, string> Formatter);
+    }
+
+    private sealed class MinimalServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType)
+        {
+            if (serviceType == typeof(Microsoft.Extensions.Hosting.IHostEnvironment))
+            {
+                return new TestHostEnvironment();
+            }
+            return null;
+        }
+
+        private sealed class TestHostEnvironment : Microsoft.Extensions.Hosting.IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = "Production";
+            public string ApplicationName { get; set; } = "Tests";
+            public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+            public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+                new Microsoft.Extensions.FileProviders.NullFileProvider();
+        }
+    }
+}


### PR DESCRIPTION
Closes the systematic gap behind CodeQL alert #1 (`cs/log-forging`, CWE-117) on `GlobalExceptionHandler.cs:19` and puts a reusable defense in place for every future log site that touches user-controlled input.

## What changed

- **New `LogSanitizer`** (`src/api/Logging/`) — strips CR/LF, NEL, LS, PS, other C0/C1 control chars, and DEL; preserves TAB; truncates to a configurable cap with an explicit `…[truncated:N]` marker. Mandatory `String.Replace('\r','_').Replace('\n','_')` first pass so CodeQL's rule recognizes the sanitizer.
- **`LogSanitizerExtensions.ForLog()`** for `string?`, `PathString`, and `QueryString`.
- **`ExceptionLoggingOptions.IncludeRawException`** (default `false`) bound from `Logging:Exceptions`.
  - **Default (false, production-safe):** logs sanitized `ExceptionType` / `ExceptionMessage` / `ExceptionStackTrace` as separate structured fields and does **not** pass the raw `Exception` to the logger. Closes CWE-117 on every sink, including plaintext console/file.
  - **Opt-in (true, debugging):** restores raw `Exception` logging for full OpenTelemetry / Application Insights structured exception telemetry, at the cost of plaintext-sink CWE-117 safety on exception fields.
- **`InternalsVisibleTo`** wired so the sanitizer can stay `internal`.
- **Tests:** `LogSanitizerTests` (control chars, TAB preservation, ANSI ESC injection, idempotence, length-cap edges) + `GlobalExceptionHandlerTests` (both modes; asserts no `\r`/`\n` in rendered output even when path AND exception message contain them).
- **Docs:** `copilot-instructions.md` gains a `Logging — Sanitize User-Controlled Input` section. `README.md` and `CONTEXT.md` updated.

## Process

- **Plan review** (GPT-5.4) — adopted blocking findings: mandatory `Replace('\r')/Replace('\n')` first pass; `InternalsVisibleTo`; handler integration test; raw-exception opt-in.
- **Final-diff review** (GPT-5.4) — one High finding dismissed with rationale: alert #1's source is `Request.Path`, sanitized in both branches; opt-in path is strictly safer than baseline; if CodeQL flags exception-message taint separately, it's the documented opt-in trade-off.
- **Pre-push verification:** `dotnet build` clean, all xUnit tests pass, `npx playwright test --reporter=list` 14/29 pass — **all 15 failures are pre-existing on `main`** (verified by running the same suite on a clean worktree at `main` and seeing identical failures). Zero new failures introduced by this branch.

## Known pre-existing E2E failures (NOT introduced here)

- 12 dark-mode tests — tracked in #43.
- 3 offline tests — being addressed in PR #41.

## Verification after merge

- Wait for CodeQL workflow to re-scan `main`; confirm alert #1 closes.
- If a new `cs/log-forging` alert appears on the `IncludeRawException=true` branch, accept as the documented opt-in trade-off (option is off by default in `appsettings.json`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
