### PR TITLE
ci: add Playwright e2e job to CI/CD as required gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -238,7 +238,7 @@ jobs:
       deploy: ${{ steps.filter.outputs.deploy }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,9 +75,64 @@ jobs:
         working-directory: src/client
         run: npm test
 
+  e2e:
+    name: E2E (Playwright)
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+          dotnet-quality: "preview"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: |
+            src/client/package-lock.json
+            tests/e2e/package-lock.json
+
+      - name: Install client dependencies
+        working-directory: src/client
+        run: npm ci
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm ci
+
+      - name: Install Playwright browser (chromium)
+        working-directory: tests/e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright e2e tests
+        working-directory: tests/e2e
+        # The Playwright config's webServer blocks auto-start the .NET API
+        # and Vite dev server. Use --reporter=list explicitly: the default
+        # html reporter spawns a blocking server on port 9323 that hangs CI.
+        run: npx playwright test --reporter=list
+
+      - name: Upload Playwright test results
+        # The list reporter doesn't generate a playwright-report/ directory
+        # (only the html reporter does), so we upload only test-results/,
+        # which contains traces, screenshots, and videos for failed tests.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: tests/e2e/test-results/
+          retention-days: 14
+
   docker-build-push:
     name: Docker Build & Push
-    needs: build-and-test
+    needs: [build-and-test, e2e]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
@@ -176,7 +231,7 @@ jobs:
 
   detect-changes:
     name: Detect deployable changes
-    needs: build-and-test
+    needs: [build-and-test, e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:

--- a/tests/e2e/specs/offline.spec.ts
+++ b/tests/e2e/specs/offline.spec.ts
@@ -20,15 +20,36 @@ test.describe('Offline Capabilities', () => {
     // Load app online first — warm-up hook caches all API data
     const settings = new SettingsPage(page);
     await settings.goto();
-    await settings.selectState('New York');
 
-    // Visit study page to ensure questions are loaded and cached
+    // Wait for the post-state-selection warm-up to actually finish, on
+    // a deterministic signal rather than a fixed timeout. ``useWarmUpCache``
+    // re-runs whenever ``stateId`` changes, so once we pick a state it
+    // fires getAllQuestions, get6520Questions, getAllStates, and
+    // getStateById in parallel. The offline tests below depend on the
+    // all-questions, 65/20 questions, and state-by-id responses being
+    // in browser cache; wait for those requests to resolve before going
+    // offline so the test never races the warm-up. A fixed waitForTimeout
+    // was previously used here, but it was either too short on slow CI
+    // or wasted time when the warm-up finished quickly.
+    const warmUpResponses = Promise.all([
+      page.waitForResponse(
+        r => /\/api\/v1\/questions\?stateId=\d+/.test(r.url()) && r.ok(),
+      ),
+      page.waitForResponse(
+        r => /\/api\/v1\/questions\/6520\?stateId=\d+/.test(r.url()) && r.ok(),
+      ),
+      page.waitForResponse(
+        r => /\/api\/v1\/states\/\d+/.test(r.url()) && r.ok(),
+      ),
+    ]);
+    await settings.selectState('New York');
+    await warmUpResponses;
+
+    // Visit study page so the StudyPage component itself has rendered
+    // at least once with the cached data before tests reload offline.
     const study = new StudyPage(page);
     await study.goto();
     await study.getQuestionText();
-
-    // Give service worker time to cache responses
-    await page.waitForTimeout(2000);
   });
 
   test('study page shows questions while offline', async ({ page, context }) => {


### PR DESCRIPTION
## Why

Until now CI ran only the frontend Vitest and backend `dotnet test` suites — the Playwright e2e tests were never invoked in CI. That's how the four broken offline / 65-20 tests sat unnoticed until they were fixed in #41. Without an e2e gate, similar regressions can land unobserved again.

## What

Adds a new `e2e` job to `.github/workflows/ci-cd.yml` that runs the full Playwright suite on every `push` and `pull_request`, and gates both the PR check and the publish/deploy path on it.

The new job:
- runs on `ubuntu-latest` with `timeout-minutes: 20`
- `needs: build-and-test` (no point running e2e if units fail)
- installs the same .NET 10 preview SDK and Node 22 used by `build-and-test`
- runs `npm ci` in `src/client` and `tests/e2e` (Playwright's `webServer` blocks auto-start the .NET API and Vite dev server; tests run against `npm run dev`, not a built artifact)
- installs Chromium with `--with-deps`
- runs `npx playwright test --reporter=list` (the default html reporter spawns a blocking server on port 9323 that hangs CI)
- on failure uploads `tests/e2e/test-results/` (traces, screenshots, videos). The list reporter does not generate `playwright-report/`, so that artifact is intentionally omitted.

To make e2e a real CD gate (not just a parallel sibling), `docker-build-push` and `detect-changes` now also list `e2e` in their `needs`. The downstream `image-smoke-test`, `deploy-plan`, and `deploy-apply` jobs chain off those, so an e2e failure on a push to `main` blocks publish, what-if, and deploy.

### Trigger scope

- The existing workflow-level `paths-ignore` (Markdown, LICENSE, instructions, templates, .gitignore, .editorconfig) is applied **only to the `push` trigger** — same as before this change. `pull_request` deliberately has no `paths-ignore`: skipping a workflow leaves any required check Pending forever, which would block merge on protected branches once e2e is required. Docs-only PRs therefore still run the full CI/CD workflow (including e2e).
- The workflow-level `concurrency` group continues to apply to the new job.

### Offline-test stabilization

The first CI run on this branch surfaced two pre-existing flakes in `offline.spec.ts` that pass locally but fail on slower ubuntu-latest runners. Their `beforeEach` used a fixed `page.waitForTimeout` to let the SW warm-up cache API responses; on slow CI that race left the cache empty. Replaced with `page.waitForResponse` against the warm-up endpoints (`/api/v1/questions`, `/api/v1/questions/6520`, `/api/v1/states/<id>`) so the test proceeds the moment the warm-up actually completes — typically <1s instead of the previous fixed wait, and reliable on CI.

Also bumped `actions/checkout@v4` to `@v6` in the `detect-changes` job for consistency with the rest of the workflow file.

## Verification

- 29 e2e tests pass locally against `origin/main` (verified before push).
- 29 e2e tests pass on the latest CI run on this branch (the new `E2E (Playwright)` check is green).
- YAML parses cleanly.
- GPT-5.4 plan review + multiple final-diff reviews; all blocking findings addressed.