### PR TITLE
ci: skip Playwright on docs-only PRs (prep for required check)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,6 +80,13 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # dorny/paths-filter uses the GitHub API on pull_request events to list
+    # changed files, which requires pull-requests: read. Declare the minimal
+    # token scope explicitly so a future tightening of the repo's default
+    # GITHUB_TOKEN permissions doesn't silently break the filter step.
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -85,13 +85,43 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Detect whether this change touches code paths that warrant a real
+      # Playwright run. Docs-only PRs (markdown anywhere, LICENSE, copilot
+      # instructions, .gitignore, .editorconfig, issue/PR templates) skip
+      # the ~35s Playwright run but the job still reports success so the
+      # required status check on main is satisfied.
+      #
+      # The pattern list mirrors on.push.paths-ignore above. We use
+      # predicate-quantifier: every with negated patterns so a file is
+      # considered "code" only when it satisfies ALL exclusions (i.e., it
+      # is none of the doc paths). The filter outputs code=true if at
+      # least one changed file is non-docs — so mixed docs+code PRs run
+      # the full Playwright suite, and only purely docs PRs skip.
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!.github/copilot-instructions.md'
+              - '!.github/instructions/**'
+              - '!.github/PULL_REQUEST_TEMPLATE.md'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.gitignore'
+              - '!.editorconfig'
+
       - name: Setup .NET
+        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
           dotnet-quality: "preview"
 
       - name: Setup Node.js
+        if: steps.filter.outputs.code == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: "22"
@@ -101,18 +131,22 @@ jobs:
             tests/e2e/package-lock.json
 
       - name: Install client dependencies
+        if: steps.filter.outputs.code == 'true'
         working-directory: src/client
         run: npm ci
 
       - name: Install e2e dependencies
+        if: steps.filter.outputs.code == 'true'
         working-directory: tests/e2e
         run: npm ci
 
       - name: Install Playwright browser (chromium)
+        if: steps.filter.outputs.code == 'true'
         working-directory: tests/e2e
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright e2e tests
+        if: steps.filter.outputs.code == 'true'
         working-directory: tests/e2e
         # The Playwright config's webServer blocks auto-start the .NET API
         # and Vite dev server. Use --reporter=list explicitly: the default
@@ -123,12 +157,16 @@ jobs:
         # The list reporter doesn't generate a playwright-report/ directory
         # (only the html reporter does), so we upload only test-results/,
         # which contains traces, screenshots, and videos for failed tests.
-        if: failure()
+        if: failure() && steps.filter.outputs.code == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-test-results
           path: tests/e2e/test-results/
           retention-days: 14
+
+      - name: Skip notice (docs-only)
+        if: steps.filter.outputs.code != 'true'
+        run: echo "Docs-only change detected — Playwright skipped, required check satisfied."
 
   docker-build-push:
     name: Docker Build & Push


### PR DESCRIPTION
## What

Make the new `E2E (Playwright)` job docs-friendly so it can safely become a required status check on `main` without imposing ~35s of Playwright work on documentation-only PRs.

## Why

PR #52 added the `E2E (Playwright)` job. The next step is adding it to the `main-protection` ruleset's required status checks. `on.push` already has `paths-ignore` for docs, but `on.pull_request` does not (and shouldn't — required checks must always run on PRs). This PR makes the e2e job fast-success on docs-only PRs.

## How

Inside the `e2e` job, add a `dorny/paths-filter@v4` step (after checkout — dorny needs the working tree on `push` events) that mirrors the existing `on.push.paths-ignore` list as negated patterns with `predicate-quantifier: every`. A file matches the `code` filter only when it satisfies all negations (i.e., is not any kind of doc).

- `code == 'true'` if at least one changed file is non-docs → run full Playwright (mixed docs+code PRs included).
- `code != 'true'` if every changed file is docs → only a final `echo` step runs; job reports success in ~10–20s.

All real Playwright steps gate on `if: steps.filter.outputs.code == 'true'`. The artifact upload also gates on `code == 'true'` so failures from skipped runs don't cause spurious uploads.

## Verification

- YAML parses (`python -c 'import yaml; yaml.safe_load(...)'`).
- Full Playwright suite green locally on `main`: 29/29 passed in 21.4s.
- Plan reviewed by GPT-5.4 (rubber-duck): identified that naive negation requires `predicate-quantifier: every` and that the filter step must follow checkout — both addressed.
- Final diff reviewed by GPT-5.4 twice; first pass flagged that a positive allowlist would miss markdown nested under `src/**` — replaced with the negation approach. Second pass clean.

## Follow-up (after merge)

Add `E2E (Playwright)` to required status checks on ruleset `main-protection` (id 15368163), preserving existing required checks (`Build & Test`, `Analyze (csharp)`, `Analyze (javascript-typescript)`).
