### PR TITLE
docs: refresh E2E Tests section (count, auto-start, reporter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,12 +334,14 @@ Automated **WCAG 2.1 AA** accessibility checks are run via `@axe-core/playwright
 
 ```bash
 cd tests/e2e
-npx playwright test                        # run all E2E tests (12 tests)
-npx playwright test accessibility          # run accessibility checks only
-npx playwright test state-selection        # run a specific spec
+npx playwright test                  # run all E2E tests (29 tests)
+npx playwright test accessibility    # run accessibility checks only
+npx playwright test state-selection  # run a specific spec
 ```
 
-> Both the API and frontend dev server must be running for E2E tests.
+> The Playwright config's `webServer` blocks auto-start the .NET API and Vite dev server — you do **not** need to start them manually.
+>
+> The repo pins `reporter: 'list'` in `playwright.config.ts`. Do not switch to the default `html` reporter for CI or agent runs — its built-in server holds port 9323 and blocks the process from exiting.
 
 ---
 


### PR DESCRIPTION
Brings the README's E2E section up to date:`r`n`r`n- 12 → **29** tests after the offline + dark-mode + 65/20 work.`r`n- Notes that `webServer` auto-starts the API + Vite dev server (no manual start).`r`n- Mentions the repo pins `reporter: 'list'` and warns against switching to the default `html` reporter (port 9323 hang).`r`n`r`nAlso a live test of the new `E2E (Playwright)` required-check + docs-skip gate from PR #54: a docs-only PR should see the e2e check turn green in ~10–20s with only the `Skip notice (docs-only)` step running.`r`n`r`nReviewed locally with GPT-5.4.