### PR TITLE
chore(deps): ignore @vitejs/plugin-react major bumps until Vite 8 unblocks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       # Re-enable when the Tailwind Vite plugin adds Vite 8 support.
       - dependency-name: "vite"
         update-types: ["version-update:semver-major"]
+      # @vitejs/plugin-react 6.x requires Vite 8 (peer "^8.0.0"); blocked transitively
+      # by the same Tailwind constraint. Re-enable together with Vite 8.
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "frontend"


### PR DESCRIPTION
## Why

Dependabot PR #49 bumps `@vitejs/plugin-react` 5.1.4 → 6.0.1 and fails CI with:

```
npm error peer vite@"^8.0.0" from @vitejs/plugin-react@6.0.1
```

`@vitejs/plugin-react` 6.x requires Vite 8. Vite 8 is **already ignored** in this same file (lines 14-17) because `@tailwindcss/vite` peer range is `^5 || ^6 || ^7`. So plugin-react 6 is transitively blocked and Dependabot will keep reopening PR #49 weekly until we tell it to skip the major.

## What

Mirror the existing Vite-major ignore on `@vitejs/plugin-react`. Minor/patch bumps still flow normally. Re-enable both ignores together once Tailwind's Vite plugin gains Vite 8 support.

## Follow-up

After merge: close PR #49 with a comment pointing here.

## Verification

- YAML scoped to `version-update:semver-major` — minor/patch unaffected.
- Local GPT-5.4 review of final diff: clean, no findings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>