### PR TITLE
fix: mobile-friendly navigation and Study header (no iPhone overflow)

### DIFF
--- a/src/client/src/components/Navigation.tsx
+++ b/src/client/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 
 export function Navigation(): React.ReactNode {
   const linkClass = ({ isActive }: { isActive: boolean }): string =>
-    `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+    `flex items-center justify-center text-center min-h-[44px] px-2 sm:px-4 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
       isActive
         ? 'bg-blue-600 text-white'
         : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-800'
@@ -10,11 +10,11 @@ export function Navigation(): React.ReactNode {
 
   return (
     <nav aria-label="Main navigation" className="bg-white dark:bg-slate-900 border-b border-gray-200 dark:border-slate-700">
-      <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
-        <h1 className="text-xl font-bold text-blue-800 dark:text-blue-300">
+      <div className="max-w-4xl mx-auto px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <h1 className="text-xl font-bold text-blue-800 dark:text-blue-300 truncate">
           🇺🇸 Naturalization Puzzle
         </h1>
-        <div className="flex gap-2" role="menubar">
+        <div className="grid grid-cols-4 gap-1 w-full sm:flex sm:gap-2 sm:w-auto" role="menubar">
           <NavLink to="/" className={linkClass} role="menuitem">Study</NavLink>
           <NavLink to="/quiz" className={linkClass} role="menuitem">Quiz</NavLink>
           <NavLink to="/history" className={linkClass} role="menuitem">History</NavLink>

--- a/src/client/src/pages/StudyPage.tsx
+++ b/src/client/src/pages/StudyPage.tsx
@@ -204,12 +204,12 @@ export function StudyPage(): React.ReactNode {
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
-      <div className="flex flex-wrap justify-between items-center gap-3 mb-4">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-4">
         <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">Study Mode</h2>
-        <div className="flex gap-2">
+        <div className="flex gap-2 w-full sm:w-auto">
           <button
             onClick={() => handleScopeChange('all')}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            className={`flex-1 sm:flex-none min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               scope === 'all'
                 ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-slate-700'
@@ -220,7 +220,7 @@ export function StudyPage(): React.ReactNode {
           </button>
           <button
             onClick={() => handleScopeChange('6520')}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+            className={`flex-1 sm:flex-none min-h-[44px] px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
               scope === '6520'
                 ? 'bg-blue-600 text-white'
                 : 'bg-gray-100 dark:bg-slate-800 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-slate-700'
@@ -312,12 +312,12 @@ export function StudyPage(): React.ReactNode {
           bar reflects "how much of what you're looking at have you studied";
           the trailing total stays grounded in the global pool. */}
       <div className="bg-white dark:bg-slate-900 rounded-lg shadow-sm p-3 mb-6">
-        <div className="flex justify-between text-sm text-gray-600 dark:text-gray-300 mb-1">
-          <span>
+        <div className="flex flex-wrap justify-between gap-x-3 gap-y-1 text-sm text-gray-600 dark:text-gray-300 mb-1">
+          <span className="break-words min-w-0">
             {studiedInCurrentSet} of {filteredQuestions.length} studied
             {searchText.trim() && ` (matching "${searchText.trim()}")`}
           </span>
-          <span>{studiedCount} total studied</span>
+          <span className="whitespace-nowrap">{studiedCount} total studied</span>
         </div>
         <div className="w-full bg-gray-200 dark:bg-slate-700 rounded-full h-2">
           <div


### PR DESCRIPTION
## Problem

On narrow viewports (~375px iPhone) the navigation (title + 4 links on one row) and the StudyPage header (title + filter buttons on one row) overflowed off-screen.

## Fix

Two-row stacked layout below the `sm` breakpoint, single-row on `sm+`:

- **Navigation**: title on row 1; 4 nav buttons as an equal-width 4-column grid on row 2. `min-h-[44px]` for tap targets and `focus-visible` rings for keyboard users. Title gets `truncate` as a safety net.
- **StudyPage header**: title above filters on mobile; filter buttons stretch to `flex-1` so they share width equally. Progress row now uses `flex-wrap` so long search-text suffixes wrap to a second line instead of overflowing.

Considered a hamburger / bottom-tab-bar but with only 4 routes a 4-column tab strip keeps everything one tap away without UI state. Skipped per-item emojis (platform variance, eats width budget) per the GPT-5.4 plan-review feedback.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | clean (1 pre-existing unrelated warning) |
| `npm test` | 84/84 unit tests |
| `npm run build` | success |
| `npx playwright test` | 29/29 e2e |
| iPhone SE (375x667) screenshots | Navigation, Study, Quiz, Settings — no overflow |

## Reviews

- **GPT-5.4 plan review** (rubber-duck) — adopted: drop emojis, add 44px tap targets + focus rings, fix progress-row wrapping; skipped: bottom tab bar (treated as future UI upgrade, not required for the overflow fix).
- **GPT-5.4 final diff review** (code-review) — No significant issues found.