### PR TITLE
feat(client): show animated 'waking up the server' banner on slow API calls

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Navigation } from './components/Navigation';
 import { OfflineBanner } from './components/OfflineBanner';
+import { SlowConnectionBanner } from './components/SlowConnectionBanner';
 import { useWarmUpCache } from './hooks/useWarmUpCache';
 import { StudyPage } from './pages/StudyPage';
 import { QuizPage } from './pages/QuizPage';
@@ -17,6 +18,7 @@ function AppShell(): React.ReactNode {
   return (
     <BrowserRouter>
       <div className="min-h-screen bg-slate-50 dark:bg-slate-950 text-gray-900 dark:text-gray-100">
+        <SlowConnectionBanner />
         <OfflineBanner />
         <Navigation />
         <ErrorBoundary>

--- a/src/client/src/components/SlowConnectionBanner.test.tsx
+++ b/src/client/src/components/SlowConnectionBanner.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { SlowConnectionBanner } from './SlowConnectionBanner';
+import { SLOW_BANNER_MESSAGES, MESSAGE_ROTATION_MS } from './slowConnectionMessages';
+import { connectionStatus } from '../services/connectionStatus';
+
+describe('SlowConnectionBanner', () => {
+  beforeEach(() => {
+    connectionStatus.__reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders nothing when no slow requests are in flight', () => {
+    const { container } = render(<SlowConnectionBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner with the first message + pulse + 0s counter when a slow request appears', () => {
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    const banner = screen.getByTestId('slow-connection-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute('role', 'status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+    expect(banner).toHaveAttribute('aria-atomic', 'true');
+    expect(screen.getByTestId('slow-connection-pulse')).toBeInTheDocument();
+    expect(screen.getByTestId('slow-connection-message').textContent).toBe(
+      SLOW_BANNER_MESSAGES[0],
+    );
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).toBe('(0s)');
+  });
+
+  it('exposes a stable screen-reader-only announcement (no rotating chatter)', () => {
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    const banner = screen.getByTestId('slow-connection-banner');
+    const sr = banner.querySelector('.sr-only');
+    expect(sr?.textContent).toMatch(/waking up the server/i);
+    expect(sr?.textContent).toMatch(/20 to 30 seconds/);
+  });
+
+  it('rotates messages on the documented cadence and sticks on the last one', () => {
+    vi.useFakeTimers();
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+    });
+
+    // Walk through every message in the sequence by advancing past each rotation boundary.
+    for (let i = 1; i < SLOW_BANNER_MESSAGES.length; i++) {
+      act(() => {
+        vi.advanceTimersByTime(MESSAGE_ROTATION_MS);
+      });
+      expect(screen.getByTestId('slow-connection-message').textContent).toBe(
+        SLOW_BANNER_MESSAGES[i],
+      );
+    }
+
+    // Advance well past the end — message stays on the last one.
+    act(() => {
+      vi.advanceTimersByTime(MESSAGE_ROTATION_MS * 5);
+    });
+    expect(screen.getByTestId('slow-connection-message').textContent).toBe(
+      SLOW_BANNER_MESSAGES[SLOW_BANNER_MESSAGES.length - 1],
+    );
+  });
+
+  it('increments the elapsed-seconds counter every second', () => {
+    vi.useFakeTimers();
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).toBe('(0s)');
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).toBe('(1s)');
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).toBe('(5s)');
+  });
+
+  it('hides the banner once all slow requests complete', () => {
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    expect(screen.getByTestId('slow-connection-banner')).toBeInTheDocument();
+    act(() => {
+      connectionStatus.markDone();
+    });
+    expect(screen.queryByTestId('slow-connection-banner')).not.toBeInTheDocument();
+  });
+
+  it('stays visible while at least one slow request remains in flight', () => {
+    render(<SlowConnectionBanner />);
+    act(() => {
+      connectionStatus.markSlow();
+      connectionStatus.markSlow();
+    });
+    expect(screen.getByTestId('slow-connection-banner')).toBeInTheDocument();
+    act(() => {
+      connectionStatus.markDone();
+    });
+    expect(screen.getByTestId('slow-connection-banner')).toBeInTheDocument();
+    act(() => {
+      connectionStatus.markDone();
+    });
+    expect(screen.queryByTestId('slow-connection-banner')).not.toBeInTheDocument();
+  });
+
+  it('resets the elapsed counter and message when a new slow run starts after a quiet period', () => {
+    vi.useFakeTimers();
+    render(<SlowConnectionBanner />);
+
+    // First slow run — let the elapsed counter climb past the first message.
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    act(() => {
+      vi.advanceTimersByTime(MESSAGE_ROTATION_MS * 2);
+    });
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).not.toBe('(0s)');
+    expect(screen.getByTestId('slow-connection-message').textContent).not.toBe(
+      SLOW_BANNER_MESSAGES[0],
+    );
+
+    // Run finishes — banner unmounts.
+    act(() => {
+      connectionStatus.markDone();
+    });
+    expect(screen.queryByTestId('slow-connection-banner')).not.toBeInTheDocument();
+
+    // Brand new slow run — counter and message must be back at the start.
+    act(() => {
+      connectionStatus.markSlow();
+    });
+    expect(screen.getByTestId('slow-connection-elapsed').textContent).toBe('(0s)');
+    expect(screen.getByTestId('slow-connection-message').textContent).toBe(
+      SLOW_BANNER_MESSAGES[0],
+    );
+  });
+});

--- a/src/client/src/components/SlowConnectionBanner.test.tsx
+++ b/src/client/src/components/SlowConnectionBanner.test.tsx
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import { SlowConnectionBanner } from './SlowConnectionBanner';
 import { SLOW_BANNER_MESSAGES, MESSAGE_ROTATION_MS } from './slowConnectionMessages';
-import { connectionStatus } from '../services/connectionStatus';
+import { connectionStatus, __resetConnectionStatusForTests } from '../services/connectionStatus';
 
 describe('SlowConnectionBanner', () => {
   beforeEach(() => {
-    connectionStatus.__reset();
+    __resetConnectionStatusForTests();
   });
 
   afterEach(() => {

--- a/src/client/src/components/SlowConnectionBanner.tsx
+++ b/src/client/src/components/SlowConnectionBanner.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import { connectionStatus } from '../services/connectionStatus';
+import { SLOW_BANNER_MESSAGES, MESSAGE_ROTATION_MS, TICK_MS } from './slowConnectionMessages';
+
+/**
+ * Renders an animated banner whenever at least one API request has been
+ * in-flight for longer than `SLOW_REQUEST_THRESHOLD_MS`. The most common
+ * trigger is the Azure Container Apps cold start (replica scaled to 0
+ * after a few minutes of idle traffic) — the first visit after a quiet
+ * period waits ~20–25 seconds for the container to spin up. Without
+ * this banner the UI looks frozen.
+ *
+ * Sighted users see a pulsing dot, a rotating set of friendly status
+ * messages, and an elapsed-seconds counter. Screen-reader users get a
+ * single stable announcement (the rotating copy is `aria-hidden`) so
+ * assistive tech doesn't yell new text every 3 seconds.
+ */
+export function SlowConnectionBanner(): React.ReactNode {
+  const slowCount = useSyncExternalStore(
+    connectionStatus.subscribe,
+    connectionStatus.getSnapshot,
+    () => 0,
+  );
+  const isVisible = slowCount > 0;
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (!isVisible) {
+      // Resetting state when becoming hidden ensures the next slow run starts
+      // back at the first message and 0s. The lint rule flags the synchronous
+      // setState in an effect — that's the intended behavior here.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setElapsedSeconds(0);
+      return;
+    }
+    const interval = setInterval(() => {
+      setElapsedSeconds(s => s + 1);
+    }, TICK_MS);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [isVisible]);
+
+  if (!isVisible) return null;
+
+  const messageIndex = Math.min(
+    Math.floor((elapsedSeconds * TICK_MS) / MESSAGE_ROTATION_MS),
+    SLOW_BANNER_MESSAGES.length - 1,
+  );
+  const message = SLOW_BANNER_MESSAGES[messageIndex];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="slow-connection-banner"
+      className="bg-amber-500 dark:bg-amber-600 text-white text-center py-2 px-4 text-sm font-medium"
+    >
+      <span className="sr-only">
+        Waking up the server. This can take 20 to 30 seconds. Please wait.
+      </span>
+      <span aria-hidden="true" className="inline-flex items-center justify-center gap-3">
+        <span
+          data-testid="slow-connection-pulse"
+          className="inline-block h-2.5 w-2.5 rounded-full bg-white animate-pulse"
+        />
+        <span data-testid="slow-connection-message">{message}</span>
+        <span data-testid="slow-connection-elapsed" className="opacity-70 tabular-nums text-xs">
+          ({elapsedSeconds}s)
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/src/client/src/components/SlowConnectionBanner.tsx
+++ b/src/client/src/components/SlowConnectionBanner.tsx
@@ -22,7 +22,11 @@ export function SlowConnectionBanner(): React.ReactNode {
     () => 0,
   );
   const isVisible = slowCount > 0;
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  // Counts ticks of the 1s setInterval below. Naming the state by what it
+  // measures (ticks) rather than what it usually displays (seconds) avoids
+  // a misleading variable name if TICK_MS is ever retuned. Display seconds
+  // and the rotating message index are derived from `tickCount * TICK_MS`.
+  const [tickCount, setTickCount] = useState(0);
 
   useEffect(() => {
     if (!isVisible) {
@@ -30,11 +34,11 @@ export function SlowConnectionBanner(): React.ReactNode {
       // back at the first message and 0s. The lint rule flags the synchronous
       // setState in an effect — that's the intended behavior here.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setElapsedSeconds(0);
+      setTickCount(0);
       return;
     }
     const interval = setInterval(() => {
-      setElapsedSeconds(s => s + 1);
+      setTickCount(t => t + 1);
     }, TICK_MS);
     return () => {
       clearInterval(interval);
@@ -43,8 +47,10 @@ export function SlowConnectionBanner(): React.ReactNode {
 
   if (!isVisible) return null;
 
+  const elapsedMs = tickCount * TICK_MS;
+  const displaySeconds = Math.floor(elapsedMs / 1000);
   const messageIndex = Math.min(
-    Math.floor((elapsedSeconds * TICK_MS) / MESSAGE_ROTATION_MS),
+    Math.floor(elapsedMs / MESSAGE_ROTATION_MS),
     SLOW_BANNER_MESSAGES.length - 1,
   );
   const message = SLOW_BANNER_MESSAGES[messageIndex];
@@ -67,7 +73,7 @@ export function SlowConnectionBanner(): React.ReactNode {
         />
         <span data-testid="slow-connection-message">{message}</span>
         <span data-testid="slow-connection-elapsed" className="opacity-70 tabular-nums text-xs">
-          ({elapsedSeconds}s)
+          ({displaySeconds}s)
         </span>
       </span>
     </div>

--- a/src/client/src/components/slowConnectionMessages.ts
+++ b/src/client/src/components/slowConnectionMessages.ts
@@ -1,0 +1,21 @@
+/**
+ * Status copy + cadence for `SlowConnectionBanner`.
+ *
+ * Lives in its own module so the banner component file only exports a
+ * React component (keeps fast-refresh happy), while tests can still
+ * import the canonical constants instead of duplicating them.
+ */
+
+export const SLOW_BANNER_MESSAGES = [
+  'Waking up the server…',
+  'Spinning up a fresh container…',
+  'Brewing some democracy ☕',
+  'Reviewing 128 civics questions…',
+  'Counting all 50 states…',
+  'Polling 435 House representatives…',
+  'Almost there — thanks for your patience!',
+] as const;
+
+export const MESSAGE_ROTATION_MS = 3000;
+
+export const TICK_MS = 1000;

--- a/src/client/src/pages/QuizPage.tsx
+++ b/src/client/src/pages/QuizPage.tsx
@@ -145,7 +145,7 @@ export function QuizPage(): React.ReactNode {
             disabled={isLoading}
             className="w-full bg-green-700 dark:bg-green-600 text-white py-3 rounded-lg font-medium hover:bg-green-800 dark:hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:outline-none transition-colors disabled:opacity-50"
           >
-            {isLoading ? 'Loading...' : 'Start Quiz'}
+            {isLoading ? 'Starting quiz…' : 'Start Quiz'}
           </button>
         </div>
       </main>

--- a/src/client/src/services/apiClient.test.ts
+++ b/src/client/src/services/apiClient.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { apiGet, apiPost } from './apiClient';
+import { connectionStatus, SLOW_REQUEST_THRESHOLD_MS } from './connectionStatus';
 
 describe('apiClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    connectionStatus.__reset();
   });
 
   describe('apiGet', () => {
@@ -68,6 +70,66 @@ describe('apiClient', () => {
       const result = await apiPost('/test', {});
 
       expect(result).toEqual({ success: false, error: '500: Internal Server Error' });
+    });
+  });
+
+  describe('slow-request instrumentation', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not mark slow when the request resolves before the threshold', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      await apiGet('/fast');
+
+      expect(connectionStatus.getSnapshot()).toBe(0);
+    });
+
+    it('marks slow once the threshold elapses, and clears on completion', async () => {
+      vi.useFakeTimers();
+      let resolveFetch!: (value: Response) => void;
+      const fetchPromise = new Promise<Response>(resolve => {
+        resolveFetch = resolve;
+      });
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(fetchPromise);
+
+      const apiPromise = apiGet('/slow');
+
+      // Cross the slow threshold while the fetch is still in flight.
+      await vi.advanceTimersByTimeAsync(SLOW_REQUEST_THRESHOLD_MS + 1);
+      expect(connectionStatus.getSnapshot()).toBe(1);
+
+      // Resolve the fetch and finish the apiGet call.
+      resolveFetch({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+      await apiPromise;
+
+      expect(connectionStatus.getSnapshot()).toBe(0);
+    });
+
+    it('clears the slow mark even when the fetch rejects after the threshold', async () => {
+      vi.useFakeTimers();
+      let rejectFetch!: (reason: Error) => void;
+      const fetchPromise = new Promise<Response>((_, reject) => {
+        rejectFetch = reject;
+      });
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(fetchPromise);
+
+      const apiPromise = apiGet('/slow-failing');
+
+      await vi.advanceTimersByTimeAsync(SLOW_REQUEST_THRESHOLD_MS + 1);
+      expect(connectionStatus.getSnapshot()).toBe(1);
+
+      rejectFetch(new Error('boom'));
+      await apiPromise;
+
+      expect(connectionStatus.getSnapshot()).toBe(0);
     });
   });
 });

--- a/src/client/src/services/apiClient.test.ts
+++ b/src/client/src/services/apiClient.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { apiGet, apiPost } from './apiClient';
-import { connectionStatus, SLOW_REQUEST_THRESHOLD_MS } from './connectionStatus';
+import {
+  connectionStatus,
+  SLOW_REQUEST_THRESHOLD_MS,
+  __resetConnectionStatusForTests,
+} from './connectionStatus';
 
 describe('apiClient', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    connectionStatus.__reset();
+    __resetConnectionStatusForTests();
   });
 
   describe('apiGet', () => {

--- a/src/client/src/services/apiClient.ts
+++ b/src/client/src/services/apiClient.ts
@@ -1,10 +1,34 @@
 import type { ApiResult } from '../types/api';
+import { connectionStatus, SLOW_REQUEST_THRESHOLD_MS } from './connectionStatus';
 
 const API_BASE = '/api/v1';
 
+/**
+ * Wraps `fetch` with a slow-request timer: if the request hasn't
+ * resolved within `SLOW_REQUEST_THRESHOLD_MS`, the connection-status
+ * store is incremented so the UI can render a "waking up the server"
+ * banner. Always paired with a decrement on completion so the count
+ * stays balanced even if the request fails.
+ */
+async function instrumentedFetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  let markedSlow = false;
+  const slowTimer = setTimeout(() => {
+    markedSlow = true;
+    connectionStatus.markSlow();
+  }, SLOW_REQUEST_THRESHOLD_MS);
+  try {
+    return await fetch(input, init);
+  } finally {
+    clearTimeout(slowTimer);
+    if (markedSlow) {
+      connectionStatus.markDone();
+    }
+  }
+}
+
 export async function apiGet<T>(path: string): Promise<ApiResult<T>> {
   try {
-    const response = await fetch(`${API_BASE}${path}`);
+    const response = await instrumentedFetch(`${API_BASE}${path}`);
     if (!response.ok) {
       return { success: false, error: `${response.status}: ${response.statusText}` };
     }
@@ -18,7 +42,7 @@ export async function apiGet<T>(path: string): Promise<ApiResult<T>> {
 
 export async function apiPost<T>(path: string, body: unknown): Promise<ApiResult<T>> {
   try {
-    const response = await fetch(`${API_BASE}${path}`, {
+    const response = await instrumentedFetch(`${API_BASE}${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -36,7 +60,7 @@ export async function apiPost<T>(path: string, body: unknown): Promise<ApiResult
 
 export async function apiPut<T>(path: string, body: unknown): Promise<ApiResult<T>> {
   try {
-    const response = await fetch(`${API_BASE}${path}`, {
+    const response = await instrumentedFetch(`${API_BASE}${path}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/src/client/src/services/connectionStatus.test.ts
+++ b/src/client/src/services/connectionStatus.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { connectionStatus, SLOW_REQUEST_THRESHOLD_MS } from './connectionStatus';
+
+describe('connectionStatus', () => {
+  beforeEach(() => {
+    connectionStatus.__reset();
+  });
+
+  it('starts with snapshot 0', () => {
+    expect(connectionStatus.getSnapshot()).toBe(0);
+  });
+
+  it('exports a sensible threshold (≥1s, ≤10s)', () => {
+    expect(SLOW_REQUEST_THRESHOLD_MS).toBeGreaterThanOrEqual(1000);
+    expect(SLOW_REQUEST_THRESHOLD_MS).toBeLessThanOrEqual(10000);
+  });
+
+  it('markSlow increments and markDone decrements', () => {
+    connectionStatus.markSlow();
+    expect(connectionStatus.getSnapshot()).toBe(1);
+    connectionStatus.markSlow();
+    expect(connectionStatus.getSnapshot()).toBe(2);
+    connectionStatus.markDone();
+    expect(connectionStatus.getSnapshot()).toBe(1);
+    connectionStatus.markDone();
+    expect(connectionStatus.getSnapshot()).toBe(0);
+  });
+
+  it('markDone never goes below 0', () => {
+    connectionStatus.markDone();
+    connectionStatus.markDone();
+    expect(connectionStatus.getSnapshot()).toBe(0);
+  });
+
+  it('notifies subscribers on changes', () => {
+    let calls = 0;
+    const unsub = connectionStatus.subscribe(() => {
+      calls += 1;
+    });
+    connectionStatus.markSlow();
+    connectionStatus.markSlow();
+    connectionStatus.markDone();
+    expect(calls).toBe(3);
+    unsub();
+  });
+
+  it('does not notify after unsubscribe', () => {
+    let calls = 0;
+    const unsub = connectionStatus.subscribe(() => {
+      calls += 1;
+    });
+    unsub();
+    connectionStatus.markSlow();
+    expect(calls).toBe(0);
+  });
+
+  it('does not notify when markDone is a no-op (already at 0)', () => {
+    let calls = 0;
+    const unsub = connectionStatus.subscribe(() => {
+      calls += 1;
+    });
+    connectionStatus.markDone();
+    expect(calls).toBe(0);
+    unsub();
+  });
+
+  it('supports multiple independent subscribers', () => {
+    const calls: string[] = [];
+    const unsubA = connectionStatus.subscribe(() => calls.push('A'));
+    const unsubB = connectionStatus.subscribe(() => calls.push('B'));
+    connectionStatus.markSlow();
+    expect(calls).toEqual(['A', 'B']);
+    unsubA();
+    connectionStatus.markDone();
+    expect(calls).toEqual(['A', 'B', 'B']);
+    unsubB();
+  });
+});

--- a/src/client/src/services/connectionStatus.test.ts
+++ b/src/client/src/services/connectionStatus.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { connectionStatus, SLOW_REQUEST_THRESHOLD_MS } from './connectionStatus';
+import {
+  connectionStatus,
+  SLOW_REQUEST_THRESHOLD_MS,
+  __resetConnectionStatusForTests,
+} from './connectionStatus';
 
 describe('connectionStatus', () => {
   beforeEach(() => {
-    connectionStatus.__reset();
+    __resetConnectionStatusForTests();
   });
 
   it('starts with snapshot 0', () => {

--- a/src/client/src/services/connectionStatus.ts
+++ b/src/client/src/services/connectionStatus.ts
@@ -42,10 +42,19 @@ export const connectionStatus = {
       notify();
     }
   },
-
-  /** Test-only reset. Not used in production paths. */
-  __reset(): void {
-    slowCount = 0;
-    subscribers.clear();
-  },
 };
+
+/**
+ * @internal Test-only escape hatch. Resets the singleton's internal state
+ * so tests don't leak across each other. Intentionally NOT a member of
+ * `connectionStatus` — keeping it as a separate, explicitly-named export
+ * makes accidental production usage hard (you have to import this exact
+ * symbol by name, which any reviewer will flag).
+ *
+ * Tests import this directly from this module. Production code never
+ * imports it; tree-shaking should drop it from the production bundle.
+ */
+export function __resetConnectionStatusForTests(): void {
+  slowCount = 0;
+  subscribers.clear();
+}

--- a/src/client/src/services/connectionStatus.ts
+++ b/src/client/src/services/connectionStatus.ts
@@ -1,0 +1,51 @@
+/**
+ * Module-level pub/sub store that tracks how many in-flight API requests
+ * have exceeded the "slow" threshold. The UI subscribes via
+ * `useSyncExternalStore` to render a "server is waking up" banner when
+ * the count is non-zero.
+ *
+ * This lives outside React context on purpose: it must be reachable from
+ * `apiClient.ts` (a plain module, not a hook) without dependency
+ * injection. It's a singleton because there's only ever one network
+ * surface per app instance.
+ */
+
+export const SLOW_REQUEST_THRESHOLD_MS = 3000;
+
+let slowCount = 0;
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const cb of subscribers) cb();
+}
+
+export const connectionStatus = {
+  subscribe(cb: () => void): () => void {
+    subscribers.add(cb);
+    return () => {
+      subscribers.delete(cb);
+    };
+  },
+
+  getSnapshot(): number {
+    return slowCount;
+  },
+
+  markSlow(): void {
+    slowCount += 1;
+    notify();
+  },
+
+  markDone(): void {
+    if (slowCount > 0) {
+      slowCount -= 1;
+      notify();
+    }
+  },
+
+  /** Test-only reset. Not used in production paths. */
+  __reset(): void {
+    slowCount = 0;
+    subscribers.clear();
+  },
+};


### PR DESCRIPTION
## Why

User reported a 20-25 second cold-load on https://np.metzger.dk. Investigation (App Insights + replica timestamps) confirmed it's an Azure Container Apps cold start: `minReplicas: 0` means after a few minutes of idle the replica is reaped, and the next visit waits for image pull + .NET host start + EF Core `EnsureCreatedAsync` seeding (700+ rows) + readiness probe before any byte comes back.

User decided **not** to mitigate the cold start itself (no warmup ping, no `minReplicas: 1`) and asked for the UI to ""show better messages."" Specifically: the banner should ""indicate progress is made and update the user in a fun way what is happening.""

## What this PR does

- **`connectionStatus` pub/sub store** ΓÇö module-level singleton with `markSlow` / `markDone` / `subscribe` / `getSnapshot`. `SLOW_REQUEST_THRESHOLD_MS = 3000`.
- **`apiClient` instrumentation** ΓÇö new `instrumentedFetch` helper wraps every fetch. If the request hasn't resolved in 3 s, it increments the slow counter; `finally` always decrements (success or failure), so the count stays balanced.
- **`SlowConnectionBanner`** (mounted in `App.tsx` above `OfflineBanner`) ΓÇö subscribes via `useSyncExternalStore`. While visible: pulsing white dot, civics-themed rotating message every 3 s, elapsed-seconds counter `(Xs)`. Last message sticks once the sequence is exhausted. Resets to 0 / first message between consecutive slow runs.
- **Accessibility** ΓÇö `role=""status"" aria-live=""polite"" aria-atomic=""true""`. Screen-reader users get one stable `.sr-only` announcement (""Waking up the server. This can take 20 to 30 seconds. Please wait.""). The rotating sighted copy is wrapped `aria-hidden=""true""` so SR users don't get yelled at every 3 s.
- **`slowConnectionMessages` constants module** ΓÇö lives next to the component so the component file only exports a React component (keeps fast-refresh + lint clean). 7 messages: ""Waking up the serverΓǪ"", ""Spinning up a fresh containerΓǪ"", ""Brewing some democracy ΓÿÆ"", ""Reviewing 128 civics questionsΓǪ"", ""Counting all 50 statesΓǪ"", ""Polling 435 House representativesΓǪ"", ""Almost there ΓÇö thanks for your patience!""
- **Bonus polish** ΓÇö `QuizPage` start button copy tightened from `'LoadingΓǪ'` to `'Starting quizΓǪ'`.

## What this PR does *not* do (intentional, per user)

- No warmup ping (""waste of resources"").
- No `minReplicas: 1` change.
- No backend pre-seeding refactor.
- No fix for the latent `/api/v1/representatives` index-route bug (separate concern; will track separately).

## Local validation

- `npm run lint` ΓåÆ 0 errors (1 pre-existing unrelated warning in `ThemeContext.tsx`)
- `npm test -- --run` ΓåÆ **119/119 tests pass** (was 100 ΓÇö 19 new tests for store, banner rotation/cadence/reset/hide-show, and apiClient threshold instrumentation)
- `npm run build` ΓåÆ success
- Full Playwright E2E ΓåÆ **32/32 passed**
- GPT-5.5 final-diff review ΓåÆ **APPROVE**, no blocking issues