### PR TITLE
feat: optional typed-input mode for story comprehension quiz with score history

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ src/client/
 | `/` | StudyPage | Browse and study all 128 civics questions; filter by category, subcategory, 65/20 set, studied/unstudied status, and namespaced tag chips (people, wars, documents, time period); keyword search; progress tracking |
 | `/quiz` | QuizPage | Take a practice quiz with typed answers and real-time scoring |
 | `/stories` | StoriesPage | Browse the Story Mode catalog — short, cited narratives that connect related civics questions into a coherent explanation, grouped by USCIS category, with an *X of N* read-progress count |
-| `/stories/:slug` | StoryPage | Read a single story (Markdown body, sources list with quoted support snippets), then take the embedded comprehension quiz. State-aware stories show a personalized preamble with the user's senators/representatives. |
-| `/history` | HistoryPage | View all past quiz attempts with summary stats (pass rate, best score, streak) and clear history |
+| `/stories/:slug` | StoryPage | Read a single story (Markdown body, sources list with quoted support snippets), then choose between two comprehension-quiz modes: **Continue with Study** (reveal-on-click flashcards) or **Continue with Quiz** (typed answers with per-question feedback and a final score). State-aware stories show a personalized preamble with the user's senators/representatives. |
+| `/history` | HistoryPage | View all past quiz attempts with summary stats (pass rate, best score, streak), plus a separate **Story Comprehension** section listing typed-mode story-quiz attempts (totals, per-story best score and attempt count, full chronological list with per-row delete + undo). |
 | `/settings` | SettingsPage | Select U.S. state, manage preferences |
 
 ### Quiz Mode
@@ -269,7 +269,10 @@ Answer checking uses case-insensitive, normalized fuzzy matching (substring + wo
 
 The app tracks which questions you've studied and your quiz history in `localStorage`. The study page shows a progress bar indicating how many questions in the current set you've reviewed.
 
-The **History page** (`/history`) shows all past quiz attempts in reverse chronological order with summary statistics: total quizzes taken, pass rate, best score, and current pass streak. Each entry shows the date, quiz mode (Standard/65/20), score, and pass/fail result. Users can clear their quiz history with a confirmation dialog (study progress is preserved).
+The **History page** (`/history`) shows two independent histories:
+
+- **All Attempts** — past `/quiz` attempts in reverse chronological order with summary statistics: total quizzes taken, pass rate, best score, and current pass streak. Each entry shows the date, quiz mode (Standard/65/20), score, and pass/fail result. Users can clear this history with a confirmation dialog (study progress is preserved).
+- **Story Comprehension** (below All Attempts) — typed-mode story-quiz attempts. Three sub-sections: a **Stats** panel (total attempts, average score across attempts), a **Per Story** aggregation (each attempted story listed with its best score and attempt count, sorted by most-recent attempt), and a **Chronological** list of every typed-mode completion with a trailing × delete button that supports a ~7-second inline **Undo**. A separate "Clear story comprehension history" link clears only this section, leaving the All Attempts history untouched. The block is hidden entirely until the user has at least one typed-mode attempt. Reveal-on-click study walkthroughs of stories are not recorded here — only typed-mode completions produce a scored entry.
 
 A **keyword search box** lets you filter questions by typing words that appear in the question text, answers, category, or subcategory (e.g., "amendment", "president", "1776"). The search works with all-word matching, combines with the other study filters, and operates entirely client-side. When no questions match, a *Clear filters* button is shown.
 
@@ -295,6 +298,11 @@ Story Mode adds short, cited narratives that connect related civics questions in
 
 See `/stories` in the running app for the full catalog.
 
+The end-of-story comprehension quiz offers two modes via a two-button chooser (no default — the user makes an explicit choice each time):
+
+- **Continue with Study** — the original reveal-on-click flow; click to show the answer, then advance.
+- **Continue with Quiz** — typed-answer drill scoped to the story's question set: the user types each answer, gets immediate per-question feedback (✓/✗ with the accepted answers), and walks through every question to a final "X out of N correct" results panel. There is no PASS/FAIL banner and no early stop — story comprehension is a study tool, not a USCIS-test simulation. Completing a typed-mode quiz appends a scored entry to the new **Story Comprehension** history on the History page (see *Study Progress* above) and marks the story as read.
+
 Each story is authored as Markdown in `content/stories/<slug>.md` with a companion `<slug>.sources.json` carrying one entry per `[N]` citation marker, including a non-empty `supportSnippet` (the layer that catches AI-fabricated citations during human review). Stories ship as `<EmbeddedResource>` in the API assembly and are parsed lazily by `StoryService` on first use; no SQL schema changes were required.
 
 The `StoryRenderer` component renders the body via a narrow custom Markdown renderer that does **not** use `dangerouslySetInnerHTML`, allowlists link protocols to `http`/`https`/`mailto`, and renders an explicit subset (paragraphs, h2/h3, lists, bold/italic, links, citation markers). XSS posture is covered by dedicated tests for `<script>` tags, event-handler attributes, and `javascript:` / `data:` / `vbscript:` URLs.
@@ -310,7 +318,7 @@ All user data is stored **client-side only** in the browser's `localStorage`. Th
 | Data | Storage | Key | Details |
 |------|---------|-----|---------|
 | Selected state ID | `localStorage` | `selectedStateId` | Numeric ID of the user's chosen U.S. state. On page load, the app hydrates full state details (capital, governor, senators, representatives) from the API. |
-| Study progress | `localStorage` | `naturalizationProgress` | Studied question IDs, quiz history (date, mode, score, pass/fail), and `storiesRead` (slugs of completed Story Mode stories). |
+| Study progress | `localStorage` | `naturalizationProgress` | Studied question IDs, `/quiz` history (date, mode, score, pass/fail), `storiesRead` (slugs of completed Story Mode stories — either mode counts), and `storyQuizHistory` (typed-mode story-quiz attempts: id, date, story slug + title, correct, total — surfaced on the History page in the *Story Comprehension* section, kept separate from `/quiz` history so the two summary-stats blocks stay independent). |
 | Theme preference | `localStorage` | `themePreference` | `'light'`, `'dark'`, or `'system'` (default). Drives the app-wide color theme. |
 | State details (capital, governor, senators, reps) | Backend API | — | Read-only, fetched from `/api/v1/states/{id}`. Cached by the service worker for offline use. |
 | Question data (128 questions) | Backend API | — | Read-only, fetched from `/api/v1/questions`. Cached by the service worker for offline use. |

--- a/src/client/src/hooks/useProgress.test.ts
+++ b/src/client/src/hooks/useProgress.test.ts
@@ -318,6 +318,41 @@ describe('useProgress', () => {
       expect(result.current.storyQuizHistory).toHaveLength(0);
     });
 
+    it('restoreStoryQuizResult is idempotent — calling it twice with the same entry does not create duplicates', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+
+      const original = result.current.storyQuizHistory[0];
+
+      act(() => {
+        result.current.removeStoryQuizResult(original.id);
+      });
+      expect(result.current.storyQuizHistory).toHaveLength(0);
+
+      // First restore inserts the entry.
+      act(() => {
+        result.current.restoreStoryQuizResult(original);
+      });
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+
+      // A second restore for the same entry (e.g. double-click on Undo) must be a no-op.
+      const beforeSecondRestore = result.current.storyQuizHistory;
+      act(() => {
+        result.current.restoreStoryQuizResult(original);
+      });
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+      expect(result.current.storyQuizHistory).toBe(beforeSecondRestore);
+      expect(result.current.storyQuizHistory[0].id).toBe(original.id);
+    });
+
     it('restoreStoryQuizResult after clearStoryQuizHistory re-adds the entry to the empty list', () => {
       const { result } = renderHook(() => useProgress());
 

--- a/src/client/src/hooks/useProgress.test.ts
+++ b/src/client/src/hooks/useProgress.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useProgress } from './useProgress';
-import type { QuizHistoryEntry } from './useProgress';
+import type { QuizHistoryEntry, StoryQuizHistoryEntry } from './useProgress';
 
 describe('useProgress', () => {
   beforeEach(() => {
@@ -168,5 +168,299 @@ describe('useProgress', () => {
     const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
     expect(stored.quizHistory).toEqual([]);
     expect(stored.studiedQuestionIds).toEqual([1, 2, 3]);
+  });
+
+  describe('storyQuizHistory', () => {
+    it('addStoryQuizResult accepts only the content fields and stamps id + date', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'The Three Branches of Government',
+          correct: 4,
+          total: 5,
+        });
+      });
+
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+      const entry = result.current.storyQuizHistory[0];
+      expect(entry.storySlug).toBe('three-branches');
+      expect(entry.storyTitle).toBe('The Three Branches of Government');
+      expect(entry.correct).toBe(4);
+      expect(entry.total).toBe(5);
+      expect(typeof entry.id).toBe('string');
+      expect(entry.id.length).toBeGreaterThan(0);
+      expect(typeof entry.date).toBe('string');
+      expect(entry.date.length).toBeGreaterThan(0);
+
+      const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+      expect(stored.storyQuizHistory).toHaveLength(1);
+      expect(stored.storyQuizHistory[0].id).toBe(entry.id);
+      expect(stored.storyQuizHistory[0].date).toBe(entry.date);
+    });
+
+    it('addStoryQuizResult produces unique ids across consecutive calls', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'The Three Branches of Government',
+          correct: 4,
+          total: 5,
+        });
+      });
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'The Three Branches of Government',
+          correct: 5,
+          total: 5,
+        });
+      });
+
+      expect(result.current.storyQuizHistory).toHaveLength(2);
+      const [a, b] = result.current.storyQuizHistory;
+      expect(a.id).not.toBe(b.id);
+    });
+
+    it('removeStoryQuizResult removes the entry with the given id', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'civil-war',
+          storyTitle: 'Civil War',
+          correct: 3,
+          total: 5,
+        });
+      });
+
+      const targetId = result.current.storyQuizHistory[0].id;
+
+      act(() => {
+        result.current.removeStoryQuizResult(targetId);
+      });
+
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+      expect(result.current.storyQuizHistory[0].storySlug).toBe('civil-war');
+
+      const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+      expect(stored.storyQuizHistory).toHaveLength(1);
+      expect(stored.storyQuizHistory[0].storySlug).toBe('civil-war');
+    });
+
+    it('removeStoryQuizResult is a no-op when the id is unknown', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+
+      const before = result.current.storyQuizHistory;
+
+      expect(() => {
+        act(() => {
+          result.current.removeStoryQuizResult('does-not-exist');
+        });
+      }).not.toThrow();
+
+      expect(result.current.storyQuizHistory).toBe(before);
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+    });
+
+    it('restoreStoryQuizResult re-inserts the entry and a subsequent remove round-trips', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+
+      const original = result.current.storyQuizHistory[0];
+
+      act(() => {
+        result.current.removeStoryQuizResult(original.id);
+      });
+      expect(result.current.storyQuizHistory).toHaveLength(0);
+
+      act(() => {
+        result.current.restoreStoryQuizResult(original);
+      });
+
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+      const restored = result.current.storyQuizHistory[0];
+      expect(restored).toEqual(original);
+      expect(restored.id).toBe(original.id);
+      expect(restored.date).toBe(original.date);
+
+      act(() => {
+        result.current.removeStoryQuizResult(original.id);
+      });
+      expect(result.current.storyQuizHistory).toHaveLength(0);
+    });
+
+    it('restoreStoryQuizResult after clearStoryQuizHistory re-adds the entry to the empty list', () => {
+      const { result } = renderHook(() => useProgress());
+
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'civil-war',
+          storyTitle: 'Civil War',
+          correct: 3,
+          total: 5,
+        });
+      });
+
+      const snapshot = result.current.storyQuizHistory[0];
+
+      act(() => {
+        result.current.clearStoryQuizHistory();
+      });
+      expect(result.current.storyQuizHistory).toEqual([]);
+
+      act(() => {
+        result.current.restoreStoryQuizResult(snapshot);
+      });
+
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+      expect(result.current.storyQuizHistory[0]).toEqual(snapshot);
+    });
+
+    it('clearStoryQuizHistory clears storyQuizHistory only and preserves other progress', () => {
+      const existingProgress = {
+        studiedQuestionIds: [1, 2, 3],
+        quizHistory: [
+          { date: '2026-01-01', mode: 'standard', correct: 12, total: 20, passed: true },
+        ],
+        storiesRead: ['three-branches'],
+        storyQuizHistory: [
+          {
+            id: 'abc',
+            date: '2026-02-01T00:00:00.000Z',
+            storySlug: 'three-branches',
+            storyTitle: 'Three Branches',
+            correct: 4,
+            total: 5,
+          },
+        ],
+      };
+      localStorage.setItem('naturalizationProgress', JSON.stringify(existingProgress));
+
+      const { result } = renderHook(() => useProgress());
+      expect(result.current.storyQuizHistory).toHaveLength(1);
+
+      act(() => {
+        result.current.clearStoryQuizHistory();
+      });
+
+      expect(result.current.storyQuizHistory).toEqual([]);
+      expect(result.current.quizHistory).toHaveLength(1);
+      expect(result.current.studiedQuestionIds).toEqual([1, 2, 3]);
+      expect(result.current.storiesRead).toEqual(['three-branches']);
+
+      const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+      expect(stored.storyQuizHistory).toEqual([]);
+      expect(stored.quizHistory).toHaveLength(1);
+      expect(stored.studiedQuestionIds).toEqual([1, 2, 3]);
+      expect(stored.storiesRead).toEqual(['three-branches']);
+    });
+
+    it('migrates a legacy persisted shape (no storyQuizHistory) to an empty list without losing other fields', () => {
+      const legacyShape = {
+        studiedQuestionIds: [10, 20, 30],
+        quizHistory: [
+          { date: '2026-01-01', mode: 'standard', correct: 18, total: 20, passed: true },
+        ],
+        storiesRead: ['three-branches'],
+        // no storyQuizHistory field
+      };
+      localStorage.setItem('naturalizationProgress', JSON.stringify(legacyShape));
+
+      const { result } = renderHook(() => useProgress());
+
+      expect(result.current.studiedQuestionIds).toEqual([10, 20, 30]);
+      expect(result.current.quizHistory).toHaveLength(1);
+      expect(result.current.storiesRead).toEqual(['three-branches']);
+      expect(result.current.storyQuizHistory).toEqual([]);
+
+      // Persisted shape on disk is still legacy until the next write.
+      const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+      expect(stored).not.toHaveProperty('storyQuizHistory');
+
+      // After the next write the persisted shape includes the new field.
+      act(() => {
+        result.current.addStoryQuizResult({
+          storySlug: 'three-branches',
+          storyTitle: 'Three Branches',
+          correct: 4,
+          total: 5,
+        });
+      });
+
+      const after = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+      expect(after.storyQuizHistory).toHaveLength(1);
+      expect(after.studiedQuestionIds).toEqual([10, 20, 30]);
+      expect(after.quizHistory).toHaveLength(1);
+      expect(after.storiesRead).toEqual(['three-branches']);
+    });
+
+    it('falls back to a non-crypto id generator when crypto.randomUUID is unavailable', () => {
+      const original = (globalThis as { crypto?: unknown }).crypto;
+      try {
+        Object.defineProperty(globalThis, 'crypto', {
+          value: undefined,
+          configurable: true,
+          writable: true,
+        });
+
+        const { result } = renderHook(() => useProgress());
+
+        act(() => {
+          result.current.addStoryQuizResult({
+            storySlug: 'three-branches',
+            storyTitle: 'Three Branches',
+            correct: 4,
+            total: 5,
+          });
+        });
+
+        const entry: StoryQuizHistoryEntry = result.current.storyQuizHistory[0];
+        expect(typeof entry.id).toBe('string');
+        expect(entry.id.length).toBeGreaterThan(0);
+      } finally {
+        Object.defineProperty(globalThis, 'crypto', {
+          value: original,
+          configurable: true,
+          writable: true,
+        });
+      }
+    });
   });
 });

--- a/src/client/src/hooks/useProgress.ts
+++ b/src/client/src/hooks/useProgress.ts
@@ -179,6 +179,7 @@ export function useProgress(): {
 
   const restoreStoryQuizResult = useCallback((entry: StoryQuizHistoryEntry): void => {
     setProgress(prev => {
+      if (prev.storyQuizHistory.some(e => e.id === entry.id)) return prev;
       const updated = {
         ...prev,
         storyQuizHistory: [...prev.storyQuizHistory, entry],

--- a/src/client/src/hooks/useProgress.ts
+++ b/src/client/src/hooks/useProgress.ts
@@ -4,6 +4,7 @@ interface StudyProgress {
   readonly studiedQuestionIds: readonly number[];
   readonly quizHistory: readonly QuizHistoryEntry[];
   readonly storiesRead: readonly string[];
+  readonly storyQuizHistory: readonly StoryQuizHistoryEntry[];
 }
 
 export interface QuizHistoryEntry {
@@ -12,6 +13,26 @@ export interface QuizHistoryEntry {
   readonly correct: number;
   readonly total: number;
   readonly passed: boolean;
+}
+
+export interface StoryQuizHistoryEntry {
+  readonly id: string;
+  readonly date: string;
+  readonly storySlug: string;
+  readonly storyTitle: string;
+  readonly correct: number;
+  readonly total: number;
+}
+
+function generateStoryQuizId(storySlug: string): string {
+  const cryptoRef: { randomUUID?: () => string } | undefined =
+    typeof globalThis !== 'undefined'
+      ? (globalThis as { crypto?: { randomUUID?: () => string } }).crypto
+      : undefined;
+  if (cryptoRef && typeof cryptoRef.randomUUID === 'function') {
+    return cryptoRef.randomUUID();
+  }
+  return `${storySlug}-${Date.now()}-${Math.random()}`;
 }
 
 const STORAGE_KEY = 'naturalizationProgress';
@@ -36,6 +57,9 @@ function migrateProgress(value: unknown): StudyProgress | null {
     studiedQuestionIds: obj.studiedQuestionIds as readonly number[],
     quizHistory: obj.quizHistory as readonly QuizHistoryEntry[],
     storiesRead: Array.isArray(obj.storiesRead) ? (obj.storiesRead as readonly string[]) : [],
+    storyQuizHistory: Array.isArray(obj.storyQuizHistory)
+      ? (obj.storyQuizHistory as readonly StoryQuizHistoryEntry[])
+      : [],
   };
 }
 
@@ -52,7 +76,7 @@ function loadProgress(): StudyProgress {
   } catch {
     // ignore corrupt data
   }
-  return { studiedQuestionIds: [], quizHistory: [], storiesRead: [] };
+  return { studiedQuestionIds: [], quizHistory: [], storiesRead: [], storyQuizHistory: [] };
 }
 
 function saveProgress(progress: StudyProgress): void {
@@ -63,11 +87,16 @@ export function useProgress(): {
   readonly studiedQuestionIds: readonly number[];
   readonly quizHistory: readonly QuizHistoryEntry[];
   readonly storiesRead: readonly string[];
+  readonly storyQuizHistory: readonly StoryQuizHistoryEntry[];
   readonly markStudied: (questionId: number) => void;
   readonly addQuizResult: (entry: QuizHistoryEntry) => void;
   readonly clearQuizHistory: () => void;
   readonly markStoryRead: (slug: string) => void;
   readonly isStoryRead: (slug: string) => boolean;
+  readonly addStoryQuizResult: (entry: Omit<StoryQuizHistoryEntry, 'id' | 'date'>) => void;
+  readonly removeStoryQuizResult: (id: string) => void;
+  readonly restoreStoryQuizResult: (entry: StoryQuizHistoryEntry) => void;
+  readonly clearStoryQuizHistory: () => void;
   readonly studiedCount: number;
 }{
   const [progress, setProgress] = useState<StudyProgress>(loadProgress);
@@ -117,15 +146,70 @@ export function useProgress(): {
     [progress.storiesRead]
   );
 
+  const addStoryQuizResult = useCallback(
+    (entry: Omit<StoryQuizHistoryEntry, 'id' | 'date'>): void => {
+      const newEntry: StoryQuizHistoryEntry = {
+        ...entry,
+        id: generateStoryQuizId(entry.storySlug),
+        date: new Date().toISOString(),
+      };
+      setProgress(prev => {
+        const updated = {
+          ...prev,
+          storyQuizHistory: [...prev.storyQuizHistory, newEntry],
+        };
+        saveProgress(updated);
+        return updated;
+      });
+    },
+    []
+  );
+
+  const removeStoryQuizResult = useCallback((id: string): void => {
+    setProgress(prev => {
+      if (!prev.storyQuizHistory.some(e => e.id === id)) return prev;
+      const updated = {
+        ...prev,
+        storyQuizHistory: prev.storyQuizHistory.filter(e => e.id !== id),
+      };
+      saveProgress(updated);
+      return updated;
+    });
+  }, []);
+
+  const restoreStoryQuizResult = useCallback((entry: StoryQuizHistoryEntry): void => {
+    setProgress(prev => {
+      const updated = {
+        ...prev,
+        storyQuizHistory: [...prev.storyQuizHistory, entry],
+      };
+      saveProgress(updated);
+      return updated;
+    });
+  }, []);
+
+  const clearStoryQuizHistory = useCallback((): void => {
+    setProgress(prev => {
+      const updated = { ...prev, storyQuizHistory: [] };
+      saveProgress(updated);
+      return updated;
+    });
+  }, []);
+
   return {
     studiedQuestionIds: progress.studiedQuestionIds,
     quizHistory: progress.quizHistory,
     storiesRead: progress.storiesRead,
+    storyQuizHistory: progress.storyQuizHistory,
     markStudied,
     addQuizResult,
     clearQuizHistory,
     markStoryRead,
     isStoryRead,
+    addStoryQuizResult,
+    removeStoryQuizResult,
+    restoreStoryQuizResult,
+    clearStoryQuizHistory,
     studiedCount: progress.studiedQuestionIds.length,
   };
 }

--- a/src/client/src/pages/HistoryPage.test.tsx
+++ b/src/client/src/pages/HistoryPage.test.tsx
@@ -1,14 +1,29 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, within, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { HistoryPage } from './HistoryPage';
-import type { QuizHistoryEntry } from '../hooks/useProgress';
+import type { QuizHistoryEntry, StoryQuizHistoryEntry } from '../hooks/useProgress';
 
 function seedHistory(entries: QuizHistoryEntry[]): void {
   localStorage.setItem(
     'naturalizationProgress',
     JSON.stringify({ studiedQuestionIds: [1, 2, 3], quizHistory: entries }),
+  );
+}
+
+function seedAll(opts: {
+  quiz?: QuizHistoryEntry[];
+  stories?: StoryQuizHistoryEntry[];
+}): void {
+  localStorage.setItem(
+    'naturalizationProgress',
+    JSON.stringify({
+      studiedQuestionIds: [1, 2, 3],
+      quizHistory: opts.quiz ?? [],
+      storiesRead: [],
+      storyQuizHistory: opts.stories ?? [],
+    }),
   );
 }
 
@@ -140,5 +155,409 @@ describe('HistoryPage', () => {
 
     expect(screen.getByLabelText('Passed')).toBeInTheDocument();
     expect(screen.getByLabelText('Failed')).toBeInTheDocument();
+  });
+});
+
+describe('HistoryPage Story Comprehension block', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function story(overrides: Partial<StoryQuizHistoryEntry>): StoryQuizHistoryEntry {
+    return {
+      id: 'sid-1',
+      date: '2026-01-01T00:00:00.000Z',
+      storySlug: 'three-branches',
+      storyTitle: 'Three Branches',
+      correct: 3,
+      total: 4,
+      ...overrides,
+    };
+  }
+
+  it('does not render the Story Comprehension section when storyQuizHistory is empty', () => {
+    seedAll({
+      quiz: [
+        { date: '2026-01-01T00:00:00.000Z', mode: 'standard', correct: 14, total: 20, passed: true },
+      ],
+      stories: [],
+    });
+    renderPage();
+    expect(screen.queryByRole('heading', { name: 'Story Comprehension' })).not.toBeInTheDocument();
+  });
+
+  it('renders the Story Comprehension section AFTER the All Attempts section in DOM order', () => {
+    seedAll({
+      quiz: [
+        { date: '2026-01-01T00:00:00.000Z', mode: 'standard', correct: 14, total: 20, passed: true },
+      ],
+      stories: [story({ id: 's1' })],
+    });
+    renderPage();
+
+    const allAttempts = screen.getByRole('heading', { name: 'All Attempts' });
+    const storyHeading = screen.getByRole('heading', { name: 'Story Comprehension' });
+    expect(allAttempts.compareDocumentPosition(storyHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renders Total Attempts and rounded integer Average Score', () => {
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'a', correct: 1, total: 2, date: '2026-01-01T00:00:00.000Z' }),
+        story({ id: 's2', storySlug: 'b', correct: 4, total: 4, date: '2026-01-02T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    const summary = screen
+      .getByRole('heading', { name: 'Story Comprehension', level: 3 })
+      .closest('section')!;
+    const stats = within(summary);
+    expect(stats.getByText('Total Attempts').previousElementSibling).toHaveTextContent('2');
+    // 1/2 + 4/4 → mean of percentages = 75 (NOT 5/6 ≈ 83)
+    expect(stats.getByText('Average Score').previousElementSibling).toHaveTextContent('75%');
+  });
+
+  it('renders per-story rows sorted by lastAttemptAt desc, with story title as a link to /stories/<slug>', () => {
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'alpha', storyTitle: 'Alpha', date: '2026-01-01T00:00:00.000Z' }),
+        story({ id: 's2', storySlug: 'beta',  storyTitle: 'Beta',  date: '2026-03-01T00:00:00.000Z' }),
+        story({ id: 's3', storySlug: 'gamma', storyTitle: 'Gamma', date: '2026-02-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    const list = screen.getByRole('list', { name: 'Story comprehension per-story summary' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(within(items[0]).getByRole('link', { name: 'Beta' })).toHaveAttribute('href', '/stories/beta');
+    expect(within(items[1]).getByRole('link', { name: 'Gamma' })).toHaveAttribute('href', '/stories/gamma');
+    expect(within(items[2]).getByRole('link', { name: 'Alpha' })).toHaveAttribute('href', '/stories/alpha');
+  });
+
+  it('breaks per-story ties on identical lastAttemptAt by storySlug ascending', () => {
+    const sameDate = '2026-01-01T00:00:00.000Z';
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'banana', storyTitle: 'Banana', date: sameDate }),
+        story({ id: 's2', storySlug: 'apple',  storyTitle: 'Apple',  date: sameDate }),
+        story({ id: 's3', storySlug: 'cherry', storyTitle: 'Cherry', date: sameDate }),
+      ],
+    });
+    renderPage();
+
+    const list = screen.getByRole('list', { name: 'Story comprehension per-story summary' });
+    const titles = within(list).getAllByRole('listitem').map(li => within(li).getByRole('link').textContent);
+    expect(titles).toEqual(['Apple', 'Banana', 'Cherry']);
+  });
+
+  it('renders chronological list sorted by date desc at render time, ignoring persisted array order', () => {
+    seedAll({
+      stories: [
+        // Persisted out-of-order on purpose
+        story({ id: 's-mid', storySlug: 'mid', storyTitle: 'Mid', date: '2026-02-01T00:00:00.000Z' }),
+        story({ id: 's-old', storySlug: 'old', storyTitle: 'Old', date: '2026-01-01T00:00:00.000Z' }),
+        story({ id: 's-new', storySlug: 'new', storyTitle: 'New', date: '2026-03-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    const list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(within(items[0]).getByRole('link').textContent).toBe('New');
+    expect(within(items[1]).getByRole('link').textContent).toBe('Mid');
+    expect(within(items[2]).getByRole('link').textContent).toBe('Old');
+    // Each chronological row links to /stories/<slug>
+    expect(within(items[0]).getByRole('link')).toHaveAttribute('href', '/stories/new');
+    expect(within(items[1]).getByRole('link')).toHaveAttribute('href', '/stories/mid');
+    expect(within(items[2]).getByRole('link')).toHaveAttribute('href', '/stories/old');
+  });
+
+  it('renders the × delete button as the trailing element in each chronological row', () => {
+    seedAll({
+      stories: [story({ id: 's1', storyTitle: 'T', storySlug: 'sl' })],
+    });
+    renderPage();
+
+    const list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    const item = within(list).getAllByRole('listitem')[0];
+    const deleteBtn = within(item).getByRole('button', { name: /^Delete attempt for T/ });
+    // The × button should be the last interactive button in the row.
+    const buttons = within(item).getAllByRole('button');
+    expect(buttons[buttons.length - 1]).toBe(deleteBtn);
+  });
+
+  it('clicking × removes the entry and shows the undo banner', async () => {
+    const user = userEvent.setup();
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'a', storyTitle: 'A', date: '2026-02-01T00:00:00.000Z' }),
+        story({ id: 's2', storySlug: 'b', storyTitle: 'B', date: '2026-01-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+
+    const list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    expect(screen.getByTestId('undo-banner')).toHaveTextContent('Entry deleted.');
+    expect(screen.getByTestId('undo-banner')).toHaveAttribute('role', 'status');
+    expect(screen.getByTestId('undo-banner')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('clicking Undo within the window restores a non-latest entry at its date-sorted position', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [
+        story({ id: 'newest', storySlug: 'new', storyTitle: 'New', date: '2026-03-01T00:00:00.000Z' }),
+        story({ id: 'middle', storySlug: 'mid', storyTitle: 'Mid', date: '2026-02-01T00:00:00.000Z' }),
+        story({ id: 'oldest', storySlug: 'old', storyTitle: 'Old', date: '2026-01-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    // Delete the MIDDLE (non-latest) entry.
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for Mid/ }));
+
+    let list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    let items = within(list).getAllByRole('listitem');
+    expect(items.map(li => within(li).getByRole('link').textContent)).toEqual(['New', 'Old']);
+
+    // Undo within the 7s window.
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    items = within(list).getAllByRole('listitem');
+    expect(items.map(li => within(li).getByRole('link').textContent)).toEqual(['New', 'Mid', 'Old']);
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('after the 7s undo window expires, the entry stays gone and the banner disappears', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'a', storyTitle: 'A', date: '2026-02-01T00:00:00.000Z' }),
+        story({ id: 's2', storySlug: 'b', storyTitle: 'B', date: '2026-01-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+    expect(screen.getByTestId('undo-banner')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(7100);
+    });
+
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+    const list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    expect(within(list).getByRole('link').textContent).toBe('B');
+
+    vi.useRealTimers();
+  });
+
+  it('clears the undo timer on unmount (no late state updates) and the deletion remains final', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [story({ id: 's1', storySlug: 'a', storyTitle: 'A' })],
+    });
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { unmount } = renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+    const callsBefore = clearSpy.mock.calls.length;
+
+    unmount();
+    expect(clearSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+
+    // Advance past the 7s window — there should be no errors and no late state writes.
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    // Re-mount: the deletion is final (entry stays gone).
+    renderPage();
+    expect(screen.getByText("You haven't taken any quizzes yet.")).toBeInTheDocument();
+
+    clearSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('cancels the undo when the user navigates to a different route', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [story({ id: 's1', storySlug: 'a', storyTitle: 'A' })],
+    });
+
+    function NavButton(): React.ReactElement {
+      const navigate = useNavigate();
+      return (
+        <button onClick={() => navigate('/elsewhere')}>go-elsewhere</button>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <>
+                <HistoryPage />
+                <NavButton />
+              </>
+            }
+          />
+          <Route path="/elsewhere" element={<div>Other page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+    expect(screen.getByTestId('undo-banner')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'go-elsewhere' }));
+    expect(screen.getByText('Other page')).toBeInTheDocument();
+
+    // Even after the window elapses, returning to the page shows deletion is final.
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    // Re-render the page fresh; deletion is persisted, no auto-restore.
+    renderPage();
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: 'Story comprehension attempt history' })).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('rapid deletions: only the most-recently deleted entry is undoable; the earlier deletion stays gone', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [
+        story({ id: 's-a', storySlug: 'a', storyTitle: 'A', date: '2026-03-01T00:00:00.000Z' }),
+        story({ id: 's-b', storySlug: 'b', storyTitle: 'B', date: '2026-02-01T00:00:00.000Z' }),
+        story({ id: 's-c', storySlug: 'c', storyTitle: 'C', date: '2026-01-01T00:00:00.000Z' }),
+      ],
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for B/ }));
+
+    // Banner now offers undo for B (most recent deletion).
+    expect(screen.getByTestId('undo-banner')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    const list = screen.getByRole('list', { name: 'Story comprehension attempt history' });
+    const titles = within(list).getAllByRole('listitem').map(li => within(li).getByRole('link').textContent);
+    // A stays deleted; B restored; C still present.
+    expect(titles).toEqual(['B', 'C']);
+
+    // Advance past where A's original timer would have fired — should be a no-op (already cleared).
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('clearing story history during a pending undo cancels the undo and removes everything', () => {
+    vi.useFakeTimers();
+    seedAll({
+      stories: [
+        story({ id: 's1', storySlug: 'a', storyTitle: 'A' }),
+        story({ id: 's2', storySlug: 'b', storyTitle: 'B' }),
+      ],
+    });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete attempt for A/ }));
+    expect(screen.getByTestId('undo-banner')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear story comprehension history' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, clear story history' }));
+
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: 'Story comprehension attempt history' })).not.toBeInTheDocument();
+
+    // Advance past the original window — banner must NOT reappear.
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(screen.queryByTestId('undo-banner')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it('Clear story comprehension history clears only storyQuizHistory; quizHistory is untouched', async () => {
+    const user = userEvent.setup();
+    seedAll({
+      quiz: [
+        { date: '2026-01-01T00:00:00.000Z', mode: 'standard', correct: 14, total: 20, passed: true },
+      ],
+      stories: [story({ id: 's1' })],
+    });
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Clear story comprehension history' }));
+    await user.click(screen.getByRole('button', { name: 'Yes, clear story history' }));
+
+    expect(screen.queryByRole('heading', { name: 'Story Comprehension' })).not.toBeInTheDocument();
+    // Original quiz history is still rendered.
+    const list = screen.getByRole('list', { name: 'Quiz attempt history' });
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+
+    const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+    expect(stored.storyQuizHistory).toEqual([]);
+    expect(stored.quizHistory).toHaveLength(1);
+  });
+
+  it('summary stats (Quizzes Taken / Pass Rate / Best Score / Pass Streak) are computed only from quizHistory', () => {
+    seedAll({
+      quiz: [
+        { date: '2026-01-01T00:00:00.000Z', mode: 'standard', correct: 18, total: 20, passed: true },
+        { date: '2026-01-02T00:00:00.000Z', mode: 'standard', correct: 5, total: 20, passed: false },
+      ],
+      stories: [
+        // Story attempts must NOT influence the per-quiz summary panel.
+        story({ id: 's1', correct: 4, total: 4 }),
+        story({ id: 's2', correct: 4, total: 4 }),
+      ],
+    });
+    renderPage();
+
+    const summary = screen.getByRole('heading', { name: 'Summary', level: 3 }).closest('section')!;
+    const stats = within(summary);
+    expect(stats.getByText('Quizzes Taken').previousElementSibling).toHaveTextContent('2');
+    expect(stats.getByText('Pass Rate').previousElementSibling).toHaveTextContent('50%');
+    expect(stats.getByText('Best Score').previousElementSibling).toHaveTextContent('18/20');
+  });
+
+  it('page-level empty state shows only when both quizHistory and storyQuizHistory are empty', () => {
+    // Story-only state should NOT show the empty placeholder.
+    seedAll({ stories: [story({ id: 's1' })] });
+    const { unmount } = renderPage();
+    expect(screen.queryByText("You haven't taken any quizzes yet.")).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Story Comprehension' })).toBeInTheDocument();
+    unmount();
+
+    // Both empty → empty state shows.
+    localStorage.clear();
+    renderPage();
+    expect(screen.getByText("You haven't taken any quizzes yet.")).toBeInTheDocument();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 });

--- a/src/client/src/pages/HistoryPage.tsx
+++ b/src/client/src/pages/HistoryPage.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useProgress } from '../hooks/useProgress';
-import type { QuizHistoryEntry } from '../hooks/useProgress';
+import type { QuizHistoryEntry, StoryQuizHistoryEntry } from '../hooks/useProgress';
+import { computeStoryStats } from '../utils/storyStats';
+
+const UNDO_WINDOW_MS = 7000;
 
 function formatDate(iso: string): string {
   try {
@@ -52,18 +55,82 @@ function computeStats(history: readonly QuizHistoryEntry[]): {
 }
 
 export function HistoryPage(): React.ReactNode {
-  const { quizHistory, clearQuizHistory } = useProgress();
+  const {
+    quizHistory,
+    storyQuizHistory,
+    clearQuizHistory,
+    removeStoryQuizResult,
+    restoreStoryQuizResult,
+    clearStoryQuizHistory,
+  } = useProgress();
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showStoryConfirm, setShowStoryConfirm] = useState(false);
+  const [pendingUndo, setPendingUndo] = useState<StoryQuizHistoryEntry | null>(null);
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearUndoTimer = useCallback((): void => {
+    if (undoTimerRef.current !== null) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current !== null) {
+        clearTimeout(undoTimerRef.current);
+        undoTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const stats = computeStats(quizHistory);
   const sortedHistory = [...quizHistory].reverse();
+
+  const storyStats = useMemo(() => computeStoryStats(storyQuizHistory), [storyQuizHistory]);
+  const sortedStoryHistory = useMemo(() => {
+    return [...storyQuizHistory].sort((a, b) => {
+      if (a.date > b.date) return -1;
+      if (a.date < b.date) return 1;
+      if (a.id < b.id) return -1;
+      if (a.id > b.id) return 1;
+      return 0;
+    });
+  }, [storyQuizHistory]);
 
   const handleClear = (): void => {
     clearQuizHistory();
     setShowConfirm(false);
   };
 
-  if (quizHistory.length === 0) {
+  const handleDeleteStoryEntry = (entry: StoryQuizHistoryEntry): void => {
+    clearUndoTimer();
+    removeStoryQuizResult(entry.id);
+    setPendingUndo(entry);
+    undoTimerRef.current = setTimeout(() => {
+      setPendingUndo(null);
+      undoTimerRef.current = null;
+    }, UNDO_WINDOW_MS);
+  };
+
+  const handleUndo = (): void => {
+    if (pendingUndo === null) return;
+    clearUndoTimer();
+    restoreStoryQuizResult(pendingUndo);
+    setPendingUndo(null);
+  };
+
+  const handleClearStoryHistory = (): void => {
+    clearUndoTimer();
+    setPendingUndo(null);
+    clearStoryQuizHistory();
+    setShowStoryConfirm(false);
+  };
+
+  const hasQuizHistory = quizHistory.length > 0;
+  const hasStoryHistory = storyQuizHistory.length > 0;
+
+  if (!hasQuizHistory && !hasStoryHistory && pendingUndo === null) {
     return (
       <main className="max-w-2xl mx-auto px-4 py-8">
         <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-6">Quiz History</h2>
@@ -85,95 +152,253 @@ export function HistoryPage(): React.ReactNode {
       <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-6">Quiz History</h2>
 
       <div className="bg-white dark:bg-slate-900 rounded-xl shadow-md p-6 space-y-6">
-        <section aria-labelledby="stats-heading">
-          <h3 id="stats-heading" className="text-lg font-semibold text-gray-700 dark:text-gray-200 mb-3">Summary</h3>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <div className="bg-blue-50 dark:bg-blue-950/40 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-blue-800 dark:text-blue-200">{stats.total}</p>
-              <p className="text-xs text-blue-600 dark:text-blue-300">Quizzes Taken</p>
-            </div>
-            <div className="bg-green-50 dark:bg-green-950/40 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-green-800 dark:text-green-200">{stats.passRate}%</p>
-              <p className="text-xs text-green-600 dark:text-green-300">Pass Rate</p>
-            </div>
-            <div className="bg-purple-50 dark:bg-purple-950/40 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-purple-800 dark:text-purple-200">{stats.bestScore ?? '–'}</p>
-              <p className="text-xs text-purple-600 dark:text-purple-300">Best Score</p>
-            </div>
-            <div className="bg-amber-50 dark:bg-amber-950/40 rounded-lg p-3 text-center">
-              <p className="text-2xl font-bold text-amber-800 dark:text-amber-200">{stats.currentStreak}</p>
-              <p className="text-xs text-amber-600 dark:text-amber-300">Pass Streak</p>
-            </div>
-          </div>
-        </section>
-
-        <section aria-labelledby="history-heading">
-          <h3 id="history-heading" className="text-lg font-semibold text-gray-700 dark:text-gray-200 mb-3">All Attempts</h3>
-          <ol className="space-y-3" aria-label="Quiz attempt history">
-            {sortedHistory.map((entry, index) => (
-              <li
-                key={`${entry.date}-${index}`}
-                className="flex items-center justify-between bg-gray-50 dark:bg-slate-800 rounded-lg p-4"
-              >
-                <div className="flex flex-col gap-1">
-                  <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
-                    {formatDate(entry.date)}
-                  </span>
-                  <span className="inline-flex items-center gap-2">
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                      entry.mode === '6520'
-                        ? 'bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-200'
-                        : 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200'
-                    }`}>
-                      {entry.mode === '6520' ? '65/20' : 'Standard'}
-                    </span>
-                  </span>
+        {hasQuizHistory && (
+          <>
+            <section aria-labelledby="stats-heading">
+              <h3 id="stats-heading" className="text-lg font-semibold text-gray-700 dark:text-gray-200 mb-3">Summary</h3>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <div className="bg-blue-50 dark:bg-blue-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-blue-800 dark:text-blue-200">{stats.total}</p>
+                  <p className="text-xs text-blue-600 dark:text-blue-300">Quizzes Taken</p>
                 </div>
-                <div className="flex items-center gap-3">
-                  <span className="text-lg font-bold text-gray-800 dark:text-gray-100">
-                    {entry.correct}/{entry.total}
-                  </span>
-                  <span className={`text-sm font-semibold ${
-                    entry.passed ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'
-                  }`} aria-label={entry.passed ? 'Passed' : 'Failed'}>
-                    {entry.passed ? '✓ Pass' : '✗ Fail'}
-                  </span>
+                <div className="bg-green-50 dark:bg-green-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-green-800 dark:text-green-200">{stats.passRate}%</p>
+                  <p className="text-xs text-green-600 dark:text-green-300">Pass Rate</p>
                 </div>
-              </li>
-            ))}
-          </ol>
-        </section>
+                <div className="bg-purple-50 dark:bg-purple-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-purple-800 dark:text-purple-200">{stats.bestScore ?? '–'}</p>
+                  <p className="text-xs text-purple-600 dark:text-purple-300">Best Score</p>
+                </div>
+                <div className="bg-amber-50 dark:bg-amber-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-amber-800 dark:text-amber-200">{stats.currentStreak}</p>
+                  <p className="text-xs text-amber-600 dark:text-amber-300">Pass Streak</p>
+                </div>
+              </div>
+            </section>
 
-        <section>
-          {showConfirm ? (
-            <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-lg p-4" role="alert">
-              <p className="text-sm text-red-800 dark:text-red-200 mb-3">
-                Are you sure? This will permanently delete all quiz history.
-              </p>
-              <div className="flex gap-2">
+            <section aria-labelledby="history-heading">
+              <h3 id="history-heading" className="text-lg font-semibold text-gray-700 dark:text-gray-200 mb-3">All Attempts</h3>
+              <ol className="space-y-3" aria-label="Quiz attempt history">
+                {sortedHistory.map((entry, index) => (
+                  <li
+                    key={`${entry.date}-${index}`}
+                    className="flex items-center justify-between bg-gray-50 dark:bg-slate-800 rounded-lg p-4"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                        {formatDate(entry.date)}
+                      </span>
+                      <span className="inline-flex items-center gap-2">
+                        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                          entry.mode === '6520'
+                            ? 'bg-purple-100 dark:bg-purple-900 text-purple-700 dark:text-purple-200'
+                            : 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-200'
+                        }`}>
+                          {entry.mode === '6520' ? '65/20' : 'Standard'}
+                        </span>
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-lg font-bold text-gray-800 dark:text-gray-100">
+                        {entry.correct}/{entry.total}
+                      </span>
+                      <span className={`text-sm font-semibold ${
+                        entry.passed ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'
+                      }`} aria-label={entry.passed ? 'Passed' : 'Failed'}>
+                        {entry.passed ? '✓ Pass' : '✗ Fail'}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </section>
+
+            <section>
+              {showConfirm ? (
+                <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-lg p-4" role="alert">
+                  <p className="text-sm text-red-800 dark:text-red-200 mb-3">
+                    Are you sure? This will permanently delete all quiz history.
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleClear}
+                      className="bg-red-600 text-white px-4 py-2 rounded text-sm hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+                    >
+                      Yes, clear history
+                    </button>
+                    <button
+                      onClick={() => setShowConfirm(false)}
+                      className="bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-200 px-4 py-2 rounded text-sm hover:bg-gray-200 dark:hover:bg-slate-600 focus:ring-2 focus:ring-gray-400"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
                 <button
-                  onClick={handleClear}
-                  className="bg-red-600 text-white px-4 py-2 rounded text-sm hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+                  onClick={() => setShowConfirm(true)}
+                  className="text-red-600 dark:text-red-400 text-sm hover:underline focus:ring-2 focus:ring-red-500 rounded px-2 py-1"
                 >
-                  Yes, clear history
+                  Clear quiz history
                 </button>
+              )}
+            </section>
+          </>
+        )}
+
+        {(hasStoryHistory || pendingUndo) && (
+          <section aria-labelledby="story-comprehension-heading" className="space-y-6">
+            <h3 id="story-comprehension-heading" className="text-lg font-semibold text-gray-700 dark:text-gray-200">
+              Story Comprehension
+            </h3>
+
+            {pendingUndo && (
+              <div
+                role="status"
+                aria-live="polite"
+                data-testid="undo-banner"
+                className="flex items-center justify-between bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-800 rounded-lg p-3"
+              >
+                <span className="text-sm text-amber-800 dark:text-amber-200">Entry deleted.</span>
                 <button
-                  onClick={() => setShowConfirm(false)}
-                  className="bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-200 px-4 py-2 rounded text-sm hover:bg-gray-200 dark:hover:bg-slate-600 focus:ring-2 focus:ring-gray-400"
+                  onClick={handleUndo}
+                  className="text-sm font-semibold text-amber-800 dark:text-amber-200 hover:underline focus:ring-2 focus:ring-amber-500 rounded px-2 py-1"
                 >
-                  Cancel
+                  Undo
                 </button>
               </div>
-            </div>
-          ) : (
-            <button
-              onClick={() => setShowConfirm(true)}
-              className="text-red-600 dark:text-red-400 text-sm hover:underline focus:ring-2 focus:ring-red-500 rounded px-2 py-1"
-            >
-              Clear quiz history
-            </button>
-          )}
-        </section>
+            )}
+
+            <section aria-labelledby="story-comprehension-stats-heading">
+              <h4
+                id="story-comprehension-stats-heading"
+                className="text-base font-semibold text-gray-700 dark:text-gray-200 mb-3"
+              >
+                Summary
+              </h4>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="bg-blue-50 dark:bg-blue-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-blue-800 dark:text-blue-200">{storyStats.totalAttempts}</p>
+                  <p className="text-xs text-blue-600 dark:text-blue-300">Total Attempts</p>
+                </div>
+                <div className="bg-green-50 dark:bg-green-950/40 rounded-lg p-3 text-center">
+                  <p className="text-2xl font-bold text-green-800 dark:text-green-200">
+                    {Math.round(storyStats.avgPercent)}%
+                  </p>
+                  <p className="text-xs text-green-600 dark:text-green-300">Average Score</p>
+                </div>
+              </div>
+            </section>
+
+            <section aria-labelledby="story-comprehension-per-story-heading">
+              <h4
+                id="story-comprehension-per-story-heading"
+                className="text-base font-semibold text-gray-700 dark:text-gray-200 mb-3"
+              >
+                By Story
+              </h4>
+              <ul className="space-y-3" aria-label="Story comprehension per-story summary">
+                {storyStats.perStory.map(row => (
+                  <li
+                    key={row.slug}
+                    className="flex items-center justify-between bg-gray-50 dark:bg-slate-800 rounded-lg p-4"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <Link
+                        to={`/stories/${row.slug}`}
+                        className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline focus:ring-2 focus:ring-blue-500 rounded"
+                      >
+                        {row.title}
+                      </Link>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {row.attemptCount} {row.attemptCount === 1 ? 'attempt' : 'attempts'}
+                      </span>
+                    </div>
+                    <span className="text-lg font-bold text-gray-800 dark:text-gray-100">
+                      {row.bestCorrect}/{row.bestTotal}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section aria-labelledby="story-comprehension-list-heading">
+              <h4
+                id="story-comprehension-list-heading"
+                className="text-base font-semibold text-gray-700 dark:text-gray-200 mb-3"
+              >
+                All Story Attempts
+              </h4>
+              <ol className="space-y-3" aria-label="Story comprehension attempt history">
+                {sortedStoryHistory.map(entry => (
+                  <li
+                    key={entry.id}
+                    className="flex items-center justify-between bg-gray-50 dark:bg-slate-800 rounded-lg p-4"
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                        {formatDate(entry.date)}
+                      </span>
+                      <Link
+                        to={`/stories/${entry.storySlug}`}
+                        className="text-xs text-blue-700 dark:text-blue-300 hover:underline focus:ring-2 focus:ring-blue-500 rounded"
+                      >
+                        {entry.storyTitle}
+                      </Link>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-lg font-bold text-gray-800 dark:text-gray-100">
+                        {entry.correct}/{entry.total}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteStoryEntry(entry)}
+                        aria-label={`Delete attempt for ${entry.storyTitle} on ${formatDate(entry.date)}`}
+                        className="text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 focus:ring-2 focus:ring-red-500 rounded px-2 py-1 text-lg leading-none"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+
+              <div className="mt-4">
+                {showStoryConfirm ? (
+                  <div
+                    className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-800 rounded-lg p-4"
+                    role="alert"
+                  >
+                    <p className="text-sm text-red-800 dark:text-red-200 mb-3">
+                      Are you sure? This will permanently delete all story comprehension history.
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleClearStoryHistory}
+                        className="bg-red-600 text-white px-4 py-2 rounded text-sm hover:bg-red-700 focus:ring-2 focus:ring-red-500"
+                      >
+                        Yes, clear story history
+                      </button>
+                      <button
+                        onClick={() => setShowStoryConfirm(false)}
+                        className="bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-200 px-4 py-2 rounded text-sm hover:bg-gray-200 dark:hover:bg-slate-600 focus:ring-2 focus:ring-gray-400"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setShowStoryConfirm(true)}
+                    className="text-red-600 dark:text-red-400 text-sm hover:underline focus:ring-2 focus:ring-red-500 rounded px-2 py-1"
+                  >
+                    Clear story comprehension history
+                  </button>
+                )}
+              </div>
+            </section>
+          </section>
+        )}
       </div>
     </main>
   );

--- a/src/client/src/pages/QuizPage.tsx
+++ b/src/client/src/pages/QuizPage.tsx
@@ -188,6 +188,7 @@ export function QuizPage(): React.ReactNode {
                   <span className={`text-lg ${answer.isCorrect ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`} aria-hidden="true">
                     {answer.isCorrect ? '✓' : '✗'}
                   </span>
+                  <span className="sr-only">{answer.isCorrect ? 'Correct' : 'Incorrect'}</span>
                   <div className="flex-1">
                     <p className="font-medium text-gray-900 dark:text-gray-100 text-sm">
                       {index + 1}. {answer.questionText}

--- a/src/client/src/pages/StoryPage.test.tsx
+++ b/src/client/src/pages/StoryPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StrictMode } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import { StoryPage } from './StoryPage';
@@ -242,9 +242,48 @@ describe('StoryPage', () => {
     expect(feedback).toHaveTextContent(/not quite/i);
     expect(feedback.className).toMatch(/red/);
     expect(feedback).toHaveTextContent(/so no branch is too powerful/i);
-
     await user.click(screen.getByTestId('story-quiz-next-question'));
     expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+  });
+
+  it('rapid double-click on Submit (typed mode) records only one answer for the current question', async () => {
+    // Regression for Copilot review on PR #86: handleSubmit must be idempotent
+    // per question. A double-click on Submit before the UI rerenders out of
+    // 'answering' phase used to inflate answers.length / skew scoring.
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    // Q1: rapid double-click on Submit (fireEvent.click does NOT await
+    // re-render between clicks, so both event handlers see the same
+    // 'answering' state — the same race the bug allowed).
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    const submitBtn = screen.getByTestId('submit-answer-btn');
+    fireEvent.click(submitBtn);
+    fireEvent.click(submitBtn);
+
+    // Feedback panel renders for Q1 with the first submitted answer.
+    const feedback = await screen.findByTestId('story-quiz-feedback');
+    expect(feedback).toHaveTextContent(/correct/i);
+
+    // Advance to Q2 — if the bug were present, the second submit would have
+    // pushed answers.length to 2 while still on Q1, causing Next to skip
+    // past Q2 directly to the results panel. Asserting we land on Q2 proves
+    // the second submit was a no-op.
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+    expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    expect(screen.queryByTestId('story-quiz-results')).toBeNull();
+
+    // Walk Q2 to results and assert the final tally matches a 2-question
+    // story (NOT 3 entries from the would-be duplicate).
+    await user.type(screen.getByTestId('quiz-answer-input'), 'wrong');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+    const results = await screen.findByTestId('story-quiz-results');
+    expect(results).toHaveTextContent(/1 out of 2 correct/i);
   });
 
   it('reaching the end of typed quiz shows results panel with X out of N, per-question review, and Try again', async () => {

--- a/src/client/src/pages/StoryPage.test.tsx
+++ b/src/client/src/pages/StoryPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StrictMode } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom';
@@ -38,6 +39,21 @@ const STORY: StoryDetailDto = {
   ],
 };
 
+// Larger fixture used to exercise the "no early stop" rule: even a streak
+// of correct answers must not trigger completion before the final question.
+const LONG_STORY: StoryDetailDto = {
+  ...STORY,
+  slug: 'long-story',
+  title: 'A Longer Story',
+  questions: [
+    { id: 100, text: 'Q1?', category: 'AG', subCategory: 'X', is6520Designated: false, tags: [], answers: ['alpha'] },
+    { id: 101, text: 'Q2?', category: 'AG', subCategory: 'X', is6520Designated: false, tags: [], answers: ['beta'] },
+    { id: 102, text: 'Q3?', category: 'AG', subCategory: 'X', is6520Designated: false, tags: [], answers: ['gamma'] },
+    { id: 103, text: 'Q4?', category: 'AG', subCategory: 'X', is6520Designated: false, tags: [], answers: ['delta'] },
+    { id: 104, text: 'Q5?', category: 'AG', subCategory: 'X', is6520Designated: false, tags: [], answers: ['epsilon'] },
+  ],
+};
+
 beforeEach(() => {
   localStorage.clear();
   vi.mocked(getStory).mockReset();
@@ -53,6 +69,28 @@ function renderAt(path: string): ReturnType<typeof render> {
       </MemoryRouter>
     </AppProvider>
   );
+}
+
+function renderAtStrict(path: string): ReturnType<typeof render> {
+  return render(
+    <StrictMode>
+      <AppProvider>
+        <MemoryRouter initialEntries={[path]}>
+          <Routes>
+            <Route path="/stories/:slug" element={<StoryPage />} />
+          </Routes>
+        </MemoryRouter>
+      </AppProvider>
+    </StrictMode>
+  );
+}
+
+function readProgress(): {
+  storiesRead?: string[];
+  storyQuizHistory?: { id: string; date: string; storySlug: string; storyTitle: string; correct: number; total: number }[];
+} {
+  const raw = localStorage.getItem('naturalizationProgress');
+  return raw ? JSON.parse(raw) : {};
 }
 
 describe('StoryPage', () => {
@@ -101,17 +139,40 @@ describe('StoryPage', () => {
     expect(screen.queryByTestId('state-preamble')).toBeNull();
   });
 
-  it('starts the comprehension quiz, hands off to QuizCard, and marks read on completion', async () => {
+  it('shows two CTAs (Continue with Study / Continue with Quiz) and no Start button before the user picks', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    renderAt('/stories/three-branches');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('continue-with-study')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('continue-with-quiz')).toBeInTheDocument();
+
+    // Neither CTA is pre-selected (no aria-pressed=true, no auto-progress).
+    const studyBtn = screen.getByTestId('continue-with-study');
+    const quizBtn = screen.getByTestId('continue-with-quiz');
+    expect(studyBtn).not.toHaveAttribute('aria-pressed', 'true');
+    expect(quizBtn).not.toHaveAttribute('aria-pressed', 'true');
+
+    // No legacy Start button.
+    expect(screen.queryByTestId('start-comprehension-quiz')).toBeNull();
+    expect(screen.queryByRole('button', { name: /^start the comprehension quiz/i })).toBeNull();
+
+    // No QuizCard rendered yet (neither study reveal nor typed input).
+    expect(screen.queryByTestId('quiz-answer-input')).toBeNull();
+    expect(screen.queryByRole('button', { name: /show.*answer/i })).toBeNull();
+  });
+
+  it('Continue with Study runs the existing reveal-on-click flow and marks the story read on completion', async () => {
     vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
     const user = userEvent.setup();
 
     renderAt('/stories/three-branches');
 
     await waitFor(() => {
-      expect(screen.getByTestId('start-comprehension-quiz')).toBeInTheDocument();
+      expect(screen.getByTestId('continue-with-study')).toBeInTheDocument();
     });
-
-    await user.click(screen.getByTestId('start-comprehension-quiz'));
+    await user.click(screen.getByTestId('continue-with-study'));
 
     // Question 1 of 2 visible.
     expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
@@ -125,8 +186,315 @@ describe('StoryPage', () => {
 
     // Done state, story marked read.
     expect(screen.getByTestId('story-quiz-done')).toBeInTheDocument();
-    const stored = JSON.parse(localStorage.getItem('naturalizationProgress')!);
+    const stored = readProgress();
     expect(stored.storiesRead).toContain('three-branches');
+    // Study mode never writes to storyQuizHistory.
+    expect(stored.storyQuizHistory ?? []).toHaveLength(0);
+  });
+
+  it('Continue with Quiz renders QuizCard in typed mode (quiz-answer-input present)', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => {
+      expect(screen.getByTestId('continue-with-quiz')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    expect(screen.getByTestId('quiz-answer-input')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /show.*answer/i })).toBeNull();
+  });
+
+  it('correct typed answer renders green per-question feedback with accepted answers; Next advances', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+
+    const feedback = await screen.findByTestId('story-quiz-feedback');
+    expect(feedback).toHaveTextContent(/correct/i);
+    expect(feedback.className).toMatch(/green/);
+    expect(feedback).toHaveTextContent(/so no branch is too powerful/i);
+
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+    expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    expect(screen.queryByTestId('story-quiz-feedback')).toBeNull();
+  });
+
+  it('wrong typed answer renders red feedback with accepted answers; Next still advances', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'something completely unrelated');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+
+    const feedback = await screen.findByTestId('story-quiz-feedback');
+    expect(feedback).toHaveTextContent(/not quite/i);
+    expect(feedback.className).toMatch(/red/);
+    expect(feedback).toHaveTextContent(/so no branch is too powerful/i);
+
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+    expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+  });
+
+  it('reaching the end of typed quiz shows results panel with X out of N, per-question review, and Try again', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    // Q1: correct
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+
+    // Q2 (last): wrong → button reads "See results"
+    await user.type(screen.getByTestId('quiz-answer-input'), 'wrong-answer');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    expect(screen.getByTestId('story-quiz-see-results')).toBeInTheDocument();
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+
+    const results = await screen.findByTestId('story-quiz-results');
+    expect(results).toHaveTextContent(/1 out of 2 correct/i);
+    expect(screen.getByTestId('story-quiz-try-again')).toBeInTheDocument();
+    expect(screen.getAllByTestId('story-review-correct')).toHaveLength(1);
+    expect(screen.getAllByTestId('story-review-incorrect')).toHaveLength(1);
+
+    // Story is marked read AND a single quiz history entry persisted.
+    const stored = readProgress();
+    expect(stored.storiesRead).toContain('three-branches');
+    expect(stored.storyQuizHistory).toHaveLength(1);
+    expect(stored.storyQuizHistory![0]).toMatchObject({
+      storySlug: 'three-branches',
+      storyTitle: STORY.title,
+      correct: 1,
+      total: 2,
+    });
+    expect(typeof stored.storyQuizHistory![0].id).toBe('string');
+    expect(stored.storyQuizHistory![0].id.length).toBeGreaterThan(0);
+    expect(typeof stored.storyQuizHistory![0].date).toBe('string');
+  });
+
+  it('typed-mode results contain NO PASS/FAIL banner or threshold language', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    // Mixed results: correct + wrong.
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'no idea');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+
+    const results = await screen.findByTestId('story-quiz-results');
+    const text = results.textContent ?? '';
+    expect(text).not.toMatch(/\bPASS(?:ED)?\b/i);
+    expect(text).not.toMatch(/\bFAIL(?:ED)?\b/i);
+    expect(text).not.toMatch(/to pass/i);
+    expect(text).not.toMatch(/needed to pass/i);
+    expect(text).not.toMatch(/threshold/i);
+  });
+
+  it('does not stop early in typed mode, even on a streak of correct answers (only the final question completes the quiz)', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: LONG_STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/long-story');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    const answers = ['alpha', 'beta', 'gamma', 'delta']; // first 4 correct, 5th still pending
+    for (let i = 0; i < answers.length; i++) {
+      await user.type(screen.getByTestId('quiz-answer-input'), answers[i]);
+      await user.click(screen.getByTestId('submit-answer-btn'));
+      // Per-question feedback shows; results panel must NOT appear yet.
+      await screen.findByTestId('story-quiz-feedback');
+      expect(screen.queryByTestId('story-quiz-results')).toBeNull();
+      // Button label is still "Next question" (not "See results") for non-final.
+      expect(screen.getByTestId('story-quiz-next-question')).toBeInTheDocument();
+      await user.click(screen.getByTestId('story-quiz-next-question'));
+    }
+
+    // Now on Q5, the final question.
+    expect(screen.getByText(/Question 5 of 5/)).toBeInTheDocument();
+    expect(screen.queryByTestId('story-quiz-results')).toBeNull();
+
+    // Persistence side effects must NOT fire until after the final question's submission.
+    expect(readProgress().storyQuizHistory ?? []).toHaveLength(0);
+    expect(readProgress().storiesRead ?? []).not.toContain('long-story');
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'epsilon');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+
+    const results = await screen.findByTestId('story-quiz-results');
+    expect(results).toHaveTextContent(/5 out of 5 correct/i);
+    const stored = readProgress();
+    expect(stored.storyQuizHistory).toHaveLength(1);
+    expect(stored.storyQuizHistory![0]).toMatchObject({ storySlug: 'long-story', correct: 5, total: 5 });
+  });
+
+  it('Try again returns to the two-CTA choice screen with state cleared', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'wrong');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+    await user.type(screen.getByTestId('quiz-answer-input'), 'wrong');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+
+    await user.click(screen.getByTestId('story-quiz-try-again'));
+
+    // Back to choice screen.
+    expect(screen.getByTestId('continue-with-study')).toBeInTheDocument();
+    expect(screen.getByTestId('continue-with-quiz')).toBeInTheDocument();
+    expect(screen.queryByTestId('story-quiz-results')).toBeNull();
+    expect(screen.queryByTestId('story-quiz-feedback')).toBeNull();
+    expect(screen.queryByTestId('quiz-answer-input')).toBeNull();
+
+    // Picking quiz again starts over from Question 1 with a clean review list.
+    await user.click(screen.getByTestId('continue-with-quiz'));
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+    expect(screen.queryByTestId('story-review-correct')).toBeNull();
+    expect(screen.queryByTestId('story-review-incorrect')).toBeNull();
+  });
+
+  it('typed-mode completion under <StrictMode> writes exactly one storyQuizHistory entry and one storiesRead entry', async () => {
+    // StrictMode mounts/unmounts/re-mounts in development, so useFetch's
+    // effect can fire more than once. mockResolvedValue (not Once) keeps
+    // returning the same payload for any extra calls.
+    vi.mocked(getStory).mockResolvedValue({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAtStrict('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'Executive Legislative Judicial');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-see-results'));
+
+    await screen.findByTestId('story-quiz-results');
+
+    const stored = readProgress();
+    expect(stored.storiesRead).toEqual(['three-branches']);
+    expect(stored.storyQuizHistory).toHaveLength(1);
+    expect(stored.storyQuizHistory![0]).toMatchObject({
+      storySlug: 'three-branches',
+      storyTitle: STORY.title,
+      correct: 2,
+      total: 2,
+    });
+    expect(stored.storyQuizHistory![0].id).toBeTruthy();
+  });
+
+  it('mid-quiz abandonment in TYPED mode (unmount before See results) writes nothing and does NOT mark the story read', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: LONG_STORY });
+    const user = userEvent.setup();
+
+    const { unmount } = renderAt('/stories/long-story');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'alpha');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await user.click(screen.getByTestId('story-quiz-next-question'));
+
+    await user.type(screen.getByTestId('quiz-answer-input'), 'beta');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    // We are now on feedback for Q2 of 5; user walks away.
+
+    unmount();
+
+    const stored = readProgress();
+    expect(stored.storyQuizHistory ?? []).toHaveLength(0);
+    expect(stored.storiesRead ?? []).not.toContain('long-story');
+  });
+
+  it('mid-quiz abandonment in TYPED mode via route navigation writes nothing and does NOT mark the story read', async () => {
+    vi.mocked(getStory)
+      .mockResolvedValueOnce({ success: true, data: LONG_STORY })
+      .mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    function NavTo({ to }: { readonly to: string }): React.ReactNode {
+      const navigate = useNavigate();
+      return (
+        <button type="button" data-testid="nav-elsewhere" onClick={() => navigate(to)}>
+          go
+        </button>
+      );
+    }
+
+    render(
+      <AppProvider>
+        <MemoryRouter initialEntries={['/stories/long-story']}>
+          <Routes>
+            <Route path="/stories/:slug" element={<StoryPage />} />
+          </Routes>
+          <NavTo to="/stories/three-branches" />
+        </MemoryRouter>
+      </AppProvider>
+    );
+
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+    await user.type(screen.getByTestId('quiz-answer-input'), 'alpha');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+
+    await user.click(screen.getByTestId('nav-elsewhere'));
+
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    const stored = readProgress();
+    expect(stored.storyQuizHistory ?? []).toHaveLength(0);
+    expect(stored.storiesRead ?? []).not.toContain('long-story');
+  });
+
+  it('mid-quiz abandonment in STUDY mode (started but not completed) does NOT mark the story read', async () => {
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    const { unmount } = renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-study'));
+    await user.click(screen.getByTestId('continue-with-study'));
+
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /show.*answer/i }));
+    // User walks away after Q1's reveal but before clicking through Q2.
+
+    unmount();
+
+    const stored = readProgress();
+    expect(stored.storiesRead ?? []).not.toContain('three-branches');
+    expect(stored.storyQuizHistory ?? []).toHaveLength(0);
   });
 
   it('shows a not-found message when the slug is unknown', async () => {

--- a/src/client/src/pages/StoryPage.test.tsx
+++ b/src/client/src/pages/StoryPage.test.tsx
@@ -192,6 +192,33 @@ describe('StoryPage', () => {
     expect(stored.storyQuizHistory ?? []).toHaveLength(0);
   });
 
+  it('rapid double-click on study-mode Next does not skip a question', async () => {
+    // Audit-whole-file regression: handleStudyNext must be idempotent for the
+    // same reason handleSubmit and handleNextOrResults are. Two rapid clicks
+    // on study-mode "Next Question" used to advance index by 2, skipping a
+    // question and triggering done(study) without the user completing every
+    // question.
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-study'));
+    await user.click(screen.getByTestId('continue-with-study'));
+
+    // Q1: reveal then double-click Next.
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /show.*answer/i }));
+    const nextBtn = screen.getByRole('button', { name: /next.*question/i });
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+
+    // Must land on Q2 (not the done banner).
+    await waitFor(() => {
+      expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('story-quiz-done')).toBeNull();
+  });
+
   it('Continue with Quiz renders QuizCard in typed mode (quiz-answer-input present)', async () => {
     vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
     const user = userEvent.setup();

--- a/src/client/src/pages/StoryPage.test.tsx
+++ b/src/client/src/pages/StoryPage.test.tsx
@@ -286,6 +286,37 @@ describe('StoryPage', () => {
     expect(results).toHaveTextContent(/1 out of 2 correct/i);
   });
 
+  it('rapid double-click on Next question (typed mode) does not skip a question', async () => {
+    // Audit-whole-file regression: handleNextOrResults must be idempotent
+    // for the same reason handleSubmit is. Two rapid clicks on Next used to
+    // bump index by 2 (skipping Q2) and trigger the done-effect with an
+    // incomplete answers array.
+    vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
+    const user = userEvent.setup();
+
+    renderAt('/stories/three-branches');
+    await waitFor(() => screen.getByTestId('continue-with-quiz'));
+    await user.click(screen.getByTestId('continue-with-quiz'));
+
+    // Q1: answer once normally, then enter feedback.
+    await user.type(screen.getByTestId('quiz-answer-input'), 'so no branch is too powerful');
+    await user.click(screen.getByTestId('submit-answer-btn'));
+    await screen.findByTestId('story-quiz-feedback');
+
+    // Rapid double-click on "Next question" — both events queue setIndex
+    // updates against the same closure. With the guard, only the first
+    // increments; without it, index would jump 0 → 2 and trigger done.
+    const nextBtn = screen.getByTestId('story-quiz-next-question');
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+
+    // We must land on Q2 (not the results panel).
+    await waitFor(() => {
+      expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('story-quiz-results')).toBeNull();
+  });
+
   it('reaching the end of typed quiz shows results panel with X out of N, per-question review, and Try again', async () => {
     vi.mocked(getStory).mockResolvedValueOnce({ success: true, data: STORY });
     const user = userEvent.setup();

--- a/src/client/src/pages/StoryPage.tsx
+++ b/src/client/src/pages/StoryPage.tsx
@@ -217,6 +217,7 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
                 >
                   {a.isCorrect ? '✓' : '✗'}
                 </span>
+                <span className="sr-only">{a.isCorrect ? 'Correct' : 'Incorrect'}</span>
                 <div className="flex-1">
                   <p className="font-medium text-gray-900 dark:text-gray-100 text-sm">
                     {i + 1}. {a.questionText}

--- a/src/client/src/pages/StoryPage.tsx
+++ b/src/client/src/pages/StoryPage.tsx
@@ -70,6 +70,11 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
 
   const handleSubmit = useCallback((userAnswer: string): void => {
     setAnswers(prev => {
+      // Idempotency guard: if we already recorded an answer for the current
+      // question (e.g. a rapid double-click on Submit before the UI rerenders
+      // out of `answering` phase), skip the second append rather than
+      // inflating answers.length / skewing scoring.
+      if (prev.length > index) return prev;
       const q = questions[index];
       if (!q) return prev;
       const isCorrect = checkAnswer(userAnswer, q.answers);
@@ -202,7 +207,7 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
         <ol className="space-y-3">
           {answers.map((a, i) => (
             <li
-              key={a.questionId}
+              key={`${i}-${a.questionId}`}
               className={`p-4 rounded-lg border-l-4 ${
                 a.isCorrect
                   ? 'border-green-500 bg-green-50 dark:bg-green-950/40'
@@ -252,7 +257,7 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
         <div className="flex justify-center">
           <QuizCard
             question={current}
-            onNext={handleStudyNext}
+            onNext={() => {}}
             questionNumber={index + 1}
             totalQuestions={questions.length}
             mode="quiz"

--- a/src/client/src/pages/StoryPage.tsx
+++ b/src/client/src/pages/StoryPage.tsx
@@ -65,8 +65,12 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
   const done = studyDone || quizDone;
 
   const handleStudyNext = useCallback((): void => {
-    setIndex(prev => prev + 1);
-  }, []);
+    // Idempotency guard (matches handleNextOrResults / handleSubmit): rapid
+    // double-click on study-mode "Next Question" used to advance index by 2,
+    // skipping a question and allowing `done(study)` to mark the story read
+    // without the user completing every question.
+    setIndex(prev => (prev > index ? prev : prev + 1));
+  }, [index]);
 
   const handleSubmit = useCallback((userAnswer: string): void => {
     setAnswers(prev => {

--- a/src/client/src/pages/StoryPage.tsx
+++ b/src/client/src/pages/StoryPage.tsx
@@ -93,9 +93,13 @@ function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQui
   }, [questions, index]);
 
   const handleNextOrResults = useCallback((): void => {
-    setIndex(prev => prev + 1);
+    // Idempotency guard: rapid double-click on the feedback "Next question" /
+    // "See results" button could queue two `setIndex(prev => prev + 1)` updates,
+    // skipping a question and allowing an incomplete answer set to be scored.
+    // If `prev > index`, the first click already advanced — the second is a no-op.
+    setIndex(prev => (prev > index ? prev : prev + 1));
     setPhase('answering');
-  }, []);
+  }, [index]);
 
   const handleTryAgain = useCallback((): void => {
     setMode('choice');

--- a/src/client/src/pages/StoryPage.tsx
+++ b/src/client/src/pages/StoryPage.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import type { QuestionDto, StoryDetailDto, ApiResult } from '../types/api';
+import type { QuestionDto, QuizAnswer, StoryDetailDto, ApiResult } from '../types/api';
 import { getStory } from '../services/storyService';
 import { useAppContext } from '../context/AppContext';
 import { useProgress } from '../hooks/useProgress';
 import { useFetch } from '../hooks/useFetch';
 import { StoryRenderer } from '../components/StoryRenderer';
 import { QuizCard } from '../components/QuizCard';
+import { checkAnswer } from '../utils/answerChecker';
 
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
 
@@ -30,71 +31,272 @@ function isSafeSourceUrl(url: string): boolean {
  * The comprehension quiz lives in its own child component so the parent
  * can reset its state by changing `key={slug}`. React Router reuses the
  * same `StoryPage` instance across route changes; without the key reset,
- * `quizStarted`/`quizIndex` would carry over from one story to the next.
+ * `mode`/`index`/`answers` would carry over from one story to the next.
+ *
+ * The quiz exposes two opt-in modes (decision A in #85): a reveal-on-click
+ * "Study" path (existing behavior, unchanged) and a typed-input "Quiz" path
+ * with per-question feedback and a final results panel. The user must
+ * explicitly pick one — there is no default and no Start button.
  */
 interface ComprehensionQuizProps {
   readonly questions: readonly QuestionDto[];
   readonly onComplete: () => void;
+  readonly onScored: (correct: number, total: number) => void;
 }
 
-function ComprehensionQuiz({ questions, onComplete }: ComprehensionQuizProps): React.ReactNode {
-  const [started, setStarted] = useState(false);
-  const [index, setIndex] = useState(0);
+type QuizMode = 'choice' | 'study' | 'quiz';
+type QuizPhase = 'answering' | 'feedback';
 
-  const onNext = useCallback((): void => {
+function ComprehensionQuiz({ questions, onComplete, onScored }: ComprehensionQuizProps): React.ReactNode {
+  const [mode, setMode] = useState<QuizMode>('choice');
+  const [index, setIndex] = useState(0);
+  const [phase, setPhase] = useState<QuizPhase>('answering');
+  const [answers, setAnswers] = useState<readonly QuizAnswer[]>([]);
+
+  // StrictMode + concurrent-rendering safety: the completion effect can
+  // fire twice on initial mount and could refire if upstream callbacks
+  // are recreated. Persistence side effects must run exactly once per
+  // transition into the done state, so a ref guards the body and is
+  // reset whenever the user clicks "Try again".
+  const completedRef = useRef(false);
+
+  const studyDone = mode === 'study' && index >= questions.length;
+  const quizDone = mode === 'quiz' && index >= questions.length;
+  const done = studyDone || quizDone;
+
+  const handleStudyNext = useCallback((): void => {
     setIndex(prev => prev + 1);
   }, []);
 
-  const done = started && index >= questions.length;
+  const handleSubmit = useCallback((userAnswer: string): void => {
+    setAnswers(prev => {
+      const q = questions[index];
+      if (!q) return prev;
+      const isCorrect = checkAnswer(userAnswer, q.answers);
+      return [
+        ...prev,
+        {
+          questionId: q.id,
+          questionText: q.text,
+          userAnswer,
+          acceptedAnswers: q.answers,
+          isCorrect,
+        },
+      ];
+    });
+    setPhase('feedback');
+  }, [questions, index]);
 
-  // Final-diff Copilot review fix: don't call onComplete from inside the
-  // setIndex updater callback — under React StrictMode (and concurrent
-  // rendering) the updater can run twice, double-invoking onComplete.
-  // The effect runs once per state transition into the done state.
+  const handleNextOrResults = useCallback((): void => {
+    setIndex(prev => prev + 1);
+    setPhase('answering');
+  }, []);
+
+  const handleTryAgain = useCallback((): void => {
+    setMode('choice');
+    setIndex(0);
+    setPhase('answering');
+    setAnswers([]);
+    completedRef.current = false;
+  }, []);
+
   useEffect(() => {
-    if (done) {
-      onComplete();
+    if (!done) return;
+    if (completedRef.current) return;
+    completedRef.current = true;
+    onComplete();
+    if (quizDone) {
+      const correct = answers.filter(a => a.isCorrect).length;
+      onScored(correct, answers.length);
     }
-  }, [done, onComplete]);
+  }, [done, quizDone, answers, onComplete, onScored]);
 
-  const current = started && index < questions.length ? questions[index] : null;
+  if (mode === 'choice') {
+    return (
+      <div className="flex flex-col sm:flex-row gap-3" role="group" aria-label="Choose how to work through the comprehension questions">
+        <button
+          type="button"
+          onClick={() => setMode('study')}
+          className="flex-1 bg-gray-100 dark:bg-slate-800 text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-slate-600 font-medium px-4 py-3 rounded-lg hover:bg-gray-200 dark:hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          data-testid="continue-with-study"
+        >
+          Continue with Study
+          <span className="block text-xs font-normal text-gray-600 dark:text-gray-400 mt-1">
+            Reveal each answer on click ({questions.length} question{questions.length === 1 ? '' : 's'})
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('quiz')}
+          className="flex-1 bg-blue-50 dark:bg-blue-950 text-blue-900 dark:text-blue-100 border border-blue-300 dark:border-blue-700 font-medium px-4 py-3 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          data-testid="continue-with-quiz"
+        >
+          Continue with Quiz
+          <span className="block text-xs font-normal text-blue-800 dark:text-blue-300 mt-1">
+            Type each answer; see your score at the end
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  if (mode === 'study') {
+    const current = index < questions.length ? questions[index] : null;
+    return (
+      <>
+        {current && (
+          <div className="flex justify-center">
+            <QuizCard
+              question={current}
+              onNext={handleStudyNext}
+              questionNumber={index + 1}
+              totalQuestions={questions.length}
+              mode="study"
+            />
+          </div>
+        )}
+        {studyDone && (
+          <div
+            className="bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg p-4 text-sm"
+            role="status"
+            aria-live="polite"
+            data-testid="story-quiz-done"
+          >
+            <p className="text-green-900 dark:text-green-100">
+              <strong>Done!</strong> You worked through all {questions.length} comprehension question{questions.length === 1 ? '' : 's'} for this story.
+            </p>
+            <Link to="/stories" className="text-blue-700 dark:text-blue-300 underline mt-2 inline-block">
+              ← Back to all stories
+            </Link>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // mode === 'quiz'
+  const current = index < questions.length ? questions[index] : null;
+  const lastAnswer = answers.length > 0 ? answers[answers.length - 1] : null;
+  const isLastQuestion = index === questions.length - 1;
+  const correctCount = answers.filter(a => a.isCorrect).length;
+
+  if (quizDone) {
+    return (
+      <div
+        className="bg-white dark:bg-slate-900 rounded-xl shadow-md p-6"
+        role="status"
+        aria-live="polite"
+        data-testid="story-quiz-results"
+      >
+        <div className="text-center mb-6">
+          <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            Quiz complete
+          </h3>
+          <p className="text-lg text-gray-800 dark:text-gray-100">
+            <span className="font-bold" data-testid="story-quiz-score">{correctCount}</span> out of{' '}
+            <span className="font-bold">{answers.length}</span> correct
+          </p>
+        </div>
+
+        <h4 className="text-base font-semibold text-gray-800 dark:text-gray-100 mb-3">Review your answers</h4>
+        <ol className="space-y-3">
+          {answers.map((a, i) => (
+            <li
+              key={a.questionId}
+              className={`p-4 rounded-lg border-l-4 ${
+                a.isCorrect
+                  ? 'border-green-500 bg-green-50 dark:bg-green-950/40'
+                  : 'border-red-500 bg-red-50 dark:bg-red-950/40'
+              }`}
+              data-testid={a.isCorrect ? 'story-review-correct' : 'story-review-incorrect'}
+            >
+              <div className="flex items-start gap-2">
+                <span
+                  className={`text-lg font-bold ${a.isCorrect ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}
+                  aria-hidden="true"
+                >
+                  {a.isCorrect ? '✓' : '✗'}
+                </span>
+                <div className="flex-1">
+                  <p className="font-medium text-gray-900 dark:text-gray-100 text-sm">
+                    {i + 1}. {a.questionText}
+                  </p>
+                  <p className={`text-sm mt-1 ${a.isCorrect ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}`}>
+                    <span className="font-medium">Your answer:</span> {a.userAnswer}
+                  </p>
+                  <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
+                    <span className="font-medium">Accepted:</span> {a.acceptedAnswers.join(' · ')}
+                  </p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        <button
+          type="button"
+          onClick={handleTryAgain}
+          className="w-full mt-6 bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-3 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          data-testid="story-quiz-try-again"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
 
   return (
     <>
-      {!started && (
-        <button
-          type="button"
-          onClick={() => setStarted(true)}
-          className="bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-          data-testid="start-comprehension-quiz"
-        >
-          Start the comprehension quiz ({questions.length} question{questions.length === 1 ? '' : 's'})
-        </button>
-      )}
-      {current && (
+      {phase === 'answering' && current && (
         <div className="flex justify-center">
           <QuizCard
             question={current}
-            onNext={onNext}
+            onNext={handleStudyNext}
             questionNumber={index + 1}
             totalQuestions={questions.length}
-            mode="study"
+            mode="quiz"
+            onSubmitAnswer={handleSubmit}
           />
         </div>
       )}
-      {done && (
+      {phase === 'feedback' && lastAnswer && (
         <div
-          className="bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 rounded-lg p-4 text-sm"
+          className={`rounded-lg border-l-4 p-4 ${
+            lastAnswer.isCorrect
+              ? 'border-green-500 bg-green-50 dark:bg-green-950/40'
+              : 'border-red-500 bg-red-50 dark:bg-red-950/40'
+          }`}
           role="status"
           aria-live="polite"
-          data-testid="story-quiz-done"
+          data-testid="story-quiz-feedback"
         >
-          <p className="text-green-900 dark:text-green-100">
-            <strong>Done!</strong> You worked through all {questions.length} comprehension question{questions.length === 1 ? '' : 's'} for this story.
-          </p>
-          <Link to="/stories" className="text-blue-700 dark:text-blue-300 underline mt-2 inline-block">
-            ← Back to all stories
-          </Link>
+          <div className="flex items-start gap-2">
+            <span
+              className={`text-xl font-bold ${lastAnswer.isCorrect ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}
+              aria-hidden="true"
+            >
+              {lastAnswer.isCorrect ? '✓' : '✗'}
+            </span>
+            <div className="flex-1">
+              <p className={`font-semibold ${lastAnswer.isCorrect ? 'text-green-900 dark:text-green-100' : 'text-red-900 dark:text-red-100'}`}>
+                {lastAnswer.isCorrect ? 'Correct' : 'Not quite'}
+              </p>
+              <p className="text-sm text-gray-800 dark:text-gray-200 mt-1">
+                <span className="font-medium">Your answer:</span> {lastAnswer.userAnswer}
+              </p>
+              <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
+                <span className="font-medium">Accepted:</span> {lastAnswer.acceptedAnswers.join(' · ')}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={handleNextOrResults}
+            className="w-full mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium px-4 py-3 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            data-testid={isLastQuestion ? 'story-quiz-see-results' : 'story-quiz-next-question'}
+          >
+            {isLastQuestion ? 'See results' : 'Next question'}
+          </button>
         </div>
       )}
     </>
@@ -104,7 +306,7 @@ function ComprehensionQuiz({ questions, onComplete }: ComprehensionQuizProps): R
 export function StoryPage(): React.ReactNode {
   const { slug } = useParams<{ slug: string }>();
   const { state } = useAppContext();
-  const { markStoryRead, isStoryRead } = useProgress();
+  const { markStoryRead, isStoryRead, addStoryQuizResult } = useProgress();
 
   const stateId = state.selectedStateId ?? undefined;
 
@@ -137,6 +339,16 @@ export function StoryPage(): React.ReactNode {
       markStoryRead(story.slug);
     }
   }, [story, isStoryRead, markStoryRead]);
+
+  const handleQuizScored = useCallback((correct: number, total: number): void => {
+    if (!story?.slug) return;
+    addStoryQuizResult({
+      storySlug: story.slug,
+      storyTitle: story.title,
+      correct,
+      total,
+    });
+  }, [story, addStoryQuizResult]);
 
   if (isLoading) {
     return (
@@ -273,6 +485,7 @@ export function StoryPage(): React.ReactNode {
           key={story.slug}
           questions={story.questions}
           onComplete={handleQuizComplete}
+          onScored={handleQuizScored}
         />
       </section>
     </main>

--- a/src/client/src/utils/storyStats.test.ts
+++ b/src/client/src/utils/storyStats.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import type { StoryQuizHistoryEntry } from '../hooks/useProgress';
+import { computeStoryStats } from './storyStats';
+
+function entry(overrides: Partial<StoryQuizHistoryEntry>): StoryQuizHistoryEntry {
+  return {
+    id: 'id-1',
+    date: '2026-01-01T00:00:00.000Z',
+    storySlug: 'slug-a',
+    storyTitle: 'Story A',
+    correct: 1,
+    total: 1,
+    ...overrides,
+  };
+}
+
+describe('computeStoryStats', () => {
+  it('returns zeroes for empty input', () => {
+    const stats = computeStoryStats([]);
+    expect(stats.totalAttempts).toBe(0);
+    expect(stats.avgPercent).toBe(0);
+    expect(stats.perStory).toEqual([]);
+  });
+
+  it('handles a single attempt', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', storyTitle: 'A', correct: 3, total: 4, date: '2026-02-01T00:00:00.000Z' }),
+    ]);
+    expect(stats.totalAttempts).toBe(1);
+    expect(stats.avgPercent).toBeCloseTo(75, 5);
+    expect(stats.perStory).toHaveLength(1);
+    expect(stats.perStory[0]).toEqual({
+      slug: 'a',
+      title: 'A',
+      bestCorrect: 3,
+      bestTotal: 4,
+      attemptCount: 1,
+      lastAttemptAt: '2026-02-01T00:00:00.000Z',
+    });
+  });
+
+  it('aggregates multiple attempts on the same story (best ratio, count, lastAttemptAt)', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', storyTitle: 'Old A', correct: 2, total: 4, date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'a2', storySlug: 'a', storyTitle: 'A',     correct: 3, total: 4, date: '2026-03-01T00:00:00.000Z' }),
+      entry({ id: 'a3', storySlug: 'a', storyTitle: 'A mid', correct: 1, total: 4, date: '2026-02-01T00:00:00.000Z' }),
+    ]);
+    expect(stats.perStory).toHaveLength(1);
+    const row = stats.perStory[0];
+    expect(row.slug).toBe('a');
+    expect(row.title).toBe('A');
+    expect(row.bestCorrect).toBe(3);
+    expect(row.bestTotal).toBe(4);
+    expect(row.attemptCount).toBe(3);
+    expect(row.lastAttemptAt).toBe('2026-03-01T00:00:00.000Z');
+  });
+
+  it('prefers higher total when ratio is tied for bestCorrect/bestTotal', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', correct: 1, total: 1, date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'a2', storySlug: 'a', correct: 4, total: 4, date: '2026-01-02T00:00:00.000Z' }),
+    ]);
+    expect(stats.perStory[0].bestCorrect).toBe(4);
+    expect(stats.perStory[0].bestTotal).toBe(4);
+  });
+
+  it('sorts perStory by lastAttemptAt desc across multiple stories', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', storyTitle: 'A', correct: 1, total: 2, date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'b1', storySlug: 'b', storyTitle: 'B', correct: 1, total: 2, date: '2026-03-01T00:00:00.000Z' }),
+      entry({ id: 'c1', storySlug: 'c', storyTitle: 'C', correct: 1, total: 2, date: '2026-02-01T00:00:00.000Z' }),
+    ]);
+    expect(stats.perStory.map(r => r.slug)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('avgPercent is mean of percentages, not sum/sum (sentinel: 1/2 + 4/4 = 75, not ~83.3)', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', correct: 1, total: 2, date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'b1', storySlug: 'b', correct: 4, total: 4, date: '2026-01-02T00:00:00.000Z' }),
+    ]);
+    expect(stats.avgPercent).toBeCloseTo(75, 5);
+    expect(stats.totalAttempts).toBe(2);
+  });
+
+  it('breaks ties on identical lastAttemptAt by storySlug ascending', () => {
+    const sameDate = '2026-01-01T00:00:00.000Z';
+    const stats = computeStoryStats([
+      entry({ id: 'b1', storySlug: 'banana', storyTitle: 'Banana', correct: 1, total: 1, date: sameDate }),
+      entry({ id: 'a1', storySlug: 'apple',  storyTitle: 'Apple',  correct: 1, total: 1, date: sameDate }),
+      entry({ id: 'c1', storySlug: 'cherry', storyTitle: 'Cherry', correct: 1, total: 1, date: sameDate }),
+    ]);
+    expect(stats.perStory.map(r => r.slug)).toEqual(['apple', 'banana', 'cherry']);
+  });
+
+  it('uses the title from the most-recent entry for each story', () => {
+    const stats = computeStoryStats([
+      entry({ id: 'a1', storySlug: 'a', storyTitle: 'Old Title', correct: 1, total: 1, date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'a2', storySlug: 'a', storyTitle: 'New Title', correct: 1, total: 1, date: '2026-02-01T00:00:00.000Z' }),
+    ]);
+    expect(stats.perStory[0].title).toBe('New Title');
+  });
+
+  it('does not mutate the input array', () => {
+    const input: readonly StoryQuizHistoryEntry[] = Object.freeze([
+      entry({ id: 'a1', storySlug: 'a', date: '2026-01-01T00:00:00.000Z' }),
+      entry({ id: 'b1', storySlug: 'b', date: '2026-02-01T00:00:00.000Z' }),
+    ]);
+    expect(() => computeStoryStats(input)).not.toThrow();
+  });
+});

--- a/src/client/src/utils/storyStats.ts
+++ b/src/client/src/utils/storyStats.ts
@@ -1,0 +1,81 @@
+import type { StoryQuizHistoryEntry } from '../hooks/useProgress';
+
+export interface PerStoryStat {
+  readonly slug: string;
+  readonly title: string;
+  readonly bestCorrect: number;
+  readonly bestTotal: number;
+  readonly attemptCount: number;
+  readonly lastAttemptAt: string;
+}
+
+export interface StoryStats {
+  readonly totalAttempts: number;
+  readonly avgPercent: number;
+  readonly perStory: readonly PerStoryStat[];
+}
+
+function ratio(entry: StoryQuizHistoryEntry): number {
+  return entry.total > 0 ? entry.correct / entry.total : 0;
+}
+
+export function computeStoryStats(entries: readonly StoryQuizHistoryEntry[]): StoryStats {
+  const totalAttempts = entries.length;
+
+  if (totalAttempts === 0) {
+    return { totalAttempts: 0, avgPercent: 0, perStory: [] };
+  }
+
+  const sumPercent = entries.reduce((acc, e) => acc + ratio(e) * 100, 0);
+  const avgPercent = sumPercent / totalAttempts;
+
+  const groups = new Map<string, StoryQuizHistoryEntry[]>();
+  for (const entry of entries) {
+    const list = groups.get(entry.storySlug);
+    if (list) {
+      list.push(entry);
+    } else {
+      groups.set(entry.storySlug, [entry]);
+    }
+  }
+
+  const perStory: PerStoryStat[] = [];
+  for (const [slug, group] of groups) {
+    let mostRecent = group[0];
+    let best = group[0];
+    for (const entry of group) {
+      if (entry.date > mostRecent.date) {
+        mostRecent = entry;
+      }
+      const bestRatio = ratio(best);
+      const entryRatio = ratio(entry);
+      if (entryRatio > bestRatio) {
+        best = entry;
+      } else if (entryRatio === bestRatio) {
+        if (entry.total > best.total) {
+          best = entry;
+        } else if (entry.total === best.total && entry.date > best.date) {
+          best = entry;
+        }
+      }
+    }
+    perStory.push({
+      slug,
+      title: mostRecent.storyTitle,
+      bestCorrect: best.correct,
+      bestTotal: best.total,
+      attemptCount: group.length,
+      lastAttemptAt: mostRecent.date,
+    });
+  }
+
+  perStory.sort((a, b) => {
+    if (a.lastAttemptAt > b.lastAttemptAt) return -1;
+    if (a.lastAttemptAt < b.lastAttemptAt) return 1;
+    if (a.slug < b.slug) return -1;
+    if (a.slug > b.slug) return 1;
+    return 0;
+  });
+
+  return { totalAttempts, avgPercent, perStory };
+}

--- a/tests/e2e/specs/story-flow.spec.ts
+++ b/tests/e2e/specs/story-flow.spec.ts
@@ -49,7 +49,7 @@ test.describe('Story Mode', () => {
     await page.goto('/stories/national-symbols-and-holidays');
     await expect(page.getByRole('heading', { level: 1, name: /National Symbols/i })).toBeVisible();
 
-    await page.getByTestId('start-comprehension-quiz').click();
+    await page.getByTestId('continue-with-study').click();
 
     // Walk through every comprehension question until the done banner appears.
     // Defensively wait for the Show Answer button on each iteration so React
@@ -85,6 +85,134 @@ test.describe('Story Mode', () => {
     await page.goto('/stories');
     const card = page.getByTestId('story-card-national-symbols-and-holidays');
     await expect(card.getByLabel('Already read')).toBeVisible();
+  });
+
+  test('typed-mode comprehension quiz scores the run, marks the story read, and surfaces in History', async ({ page }) => {
+    // Issue #85 Phase 4: end-to-end coverage of the opt-in typed-input
+    // comprehension quiz on /stories/three-branches. Walks the full
+    // user journey: state selection → story page → pick "Continue with
+    // Quiz" (NOT a single Start button) → submit one known-correct
+    // answer → assert green per-question feedback → walk to the end
+    // → assert results panel ("X out of N correct") → assert NO
+    // PASS/FAIL banner copy → assert read state persisted → /history
+    // → assert the new Story Comprehension block + per-story row +
+    // chronological row with the matching score.
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.selectState('California');
+
+    await page.goto('/stories/three-branches');
+    await expect(page.getByRole('heading', { level: 1, name: /Three Branches/i })).toBeVisible();
+
+    // Decision A: two-CTA chooser, no default Start button.
+    const continueWithStudy = page.getByTestId('continue-with-study');
+    const continueWithQuiz = page.getByTestId('continue-with-quiz');
+    await expect(continueWithStudy).toBeVisible();
+    await expect(continueWithQuiz).toBeVisible();
+    await expect(page.getByTestId('quiz-answer-input')).toHaveCount(0);
+
+    await continueWithQuiz.click();
+
+    // Question 1 of three-branches is seeded as Q15
+    // ("There are three branches of government. Why?") with
+    // "Checks and balances" among its accepted answers — see
+    // src/api/Data/SeedData.cs. Submit that as a known-correct
+    // answer so we can assert the green per-question feedback.
+    const answerInput = page.getByTestId('quiz-answer-input');
+    await expect(answerInput).toBeVisible();
+    await answerInput.fill('Checks and balances');
+    await page.getByTestId('submit-answer-btn').click();
+
+    const feedback = page.getByTestId('story-quiz-feedback');
+    await expect(feedback).toBeVisible();
+    // Decision B: per-question feedback. Green panel + "Correct" copy.
+    await expect(feedback).toContainText(/Correct/);
+
+    // The first answer was correct; capture the running tally so we can
+    // verify the chronological History row matches.
+    let correctSoFar = 1;
+    let totalAnswered = 1;
+
+    // Walk the remaining questions. For each: type any answer (we type
+    // an obviously-wrong sentinel so the tally is deterministic), submit,
+    // assert the next feedback panel renders, then advance with Next or
+    // See results. The story has 16 comprehension questions per the
+    // catalog (questionIds: [15, 16, 17, 18, 19, 21, 22, 23, 24, 25,
+    // 29, 36, 41, 50, 52, 53]) but the loop is bounded defensively.
+    const wrongAnswer = 'zzzzzz-not-a-real-answer';
+    for (let i = 0; i < 50; i++) {
+      const seeResults = page.getByTestId('story-quiz-see-results');
+      const nextQuestion = page.getByTestId('story-quiz-next-question');
+      if (await seeResults.isVisible().catch(() => false)) {
+        await seeResults.click();
+        break;
+      }
+      await nextQuestion.click();
+
+      // Next question's input should mount.
+      const input = page.getByTestId('quiz-answer-input');
+      try {
+        await input.waitFor({ state: 'visible', timeout: 5000 });
+      } catch {
+        // No more inputs — likely the results panel is up. Loop again
+        // to let the "See results" branch above terminate cleanly.
+        continue;
+      }
+      await input.fill(wrongAnswer);
+      await page.getByTestId('submit-answer-btn').click();
+      await expect(page.getByTestId('story-quiz-feedback')).toBeVisible();
+      totalAnswered += 1;
+      // wrongAnswer never matches, so correctSoFar stays at 1.
+    }
+
+    // Decision C: results panel renders with "X out of N correct" and
+    // NO PASS/FAIL banner copy.
+    const results = page.getByTestId('story-quiz-results');
+    await expect(results).toBeVisible();
+    await expect(results).toContainText(`${correctSoFar} out of ${totalAnswered} correct`);
+    await expect(results.getByText(/^PASS$/)).toHaveCount(0);
+    await expect(results.getByText(/^FAIL$/)).toHaveCount(0);
+    await expect(results.getByText(/Passed/)).toHaveCount(0);
+    await expect(results.getByText(/Failed/)).toHaveCount(0);
+
+    // Story is marked read (no early stop; full run completed).
+    const stored = await page.evaluate(() => localStorage.getItem('naturalizationProgress'));
+    expect(stored).toBeTruthy();
+    const parsed = JSON.parse(stored!) as {
+      readonly storiesRead?: readonly string[];
+      readonly storyQuizHistory?: readonly { readonly storySlug: string; readonly correct: number; readonly total: number }[];
+    };
+    expect(parsed.storiesRead).toContain('three-branches');
+    // Decision D: separate storyQuizHistory list captured the run.
+    expect(parsed.storyQuizHistory).toBeTruthy();
+    const lastEntry = parsed.storyQuizHistory!.find(e => e.storySlug === 'three-branches');
+    expect(lastEntry).toBeTruthy();
+    expect(lastEntry!.correct).toBe(correctSoFar);
+    expect(lastEntry!.total).toBe(totalAnswered);
+
+    // Decision P: Story Comprehension block rendered on /history.
+    await page.goto('/history');
+    await expect(page.getByRole('heading', { level: 3, name: 'Story Comprehension' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 4, name: 'Summary' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 4, name: 'By Story' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 4, name: 'All Story Attempts' })).toBeVisible();
+
+    // Decision J: per-story title links to /stories/<slug>. Find the
+    // per-story row for three-branches and assert its best-score cell
+    // matches the just-completed run.
+    const perStoryList = page.getByRole('list', { name: /Story comprehension per-story summary/i });
+    const perStoryRow = perStoryList.locator('li', { hasText: /Three Branches/i });
+    await expect(perStoryRow).toBeVisible();
+    await expect(perStoryRow).toContainText(`${correctSoFar}/${totalAnswered}`);
+    await expect(perStoryRow.getByRole('link', { name: /Three Branches/i }))
+      .toHaveAttribute('href', '/stories/three-branches');
+
+    // Chronological list contains a row for this run with the same score.
+    const chronoList = page.getByRole('list', { name: /Story comprehension attempt history/i });
+    const chronoRow = chronoList.locator('li', { hasText: /Three Branches/i }).first();
+    await expect(chronoRow).toBeVisible();
+    await expect(chronoRow).toContainText(`${correctSoFar}/${totalAnswered}`);
   });
 
   test('a story remains readable after going offline (warm-up contract)', async ({ page, context }) => {


### PR DESCRIPTION
Implements [issue #85](https://github.com/henrik-me/NaturalizationPuzzle/issues/85) — Story comprehension quiz: optional typed-input mode with score history.

## What this PR adds

A second comprehension-quiz mode on every story page, plus a dedicated history block on the History page for those scored attempts.

- **Two-CTA chooser** on every `/stories/:slug` page (no default selected): `Continue with Study` (today's reveal-on-click flow) or `Continue with Quiz` (typed-answer drill scoped to the story).
- **Typed-mode flow**: type answer → Submit → per-question feedback panel (✓ green / ✗ red, with the accepted answers shown for screen readers via an `sr-only` label too) → Next → … → final results panel "X out of N correct". **No PASS/FAIL banner**, **no early stop** — story comprehension is a study tool, not a USCIS-test simulation. "Try again" returns to the two-CTA choice screen with state cleared.
- **Scored attempts persisted** in a new `naturalizationProgress.storyQuizHistory` array, separate from the existing `quizHistory` so the existing /quiz summary stats (Pass Rate / Best Score / Pass Streak) stay anchored on USCIS thresholds. Migration is backwards-compatible (missing key defaults to `[]`).
- **History page gains a "Story Comprehension" block** below the existing "All Attempts":
  - **Stats panel** — Total Attempts + Average Score (mean of per-attempt percentages, `Math.round` → integer percent).
  - **Per-Story aggregation** — best score and attempt count for each story attempted, sorted by most-recent attempt (tie-break by slug asc); story title links to `/stories/<slug>`.
  - **Chronological list** — every typed-mode completion sorted by date desc at render time (tie-break by id asc), with a trailing `×` per row that supports a ~7-second inline `Undo` banner. Independent "Clear story comprehension history" link.
- **Reveal-on-click (Study) mode** still marks the story read but produces no scored entry — symmetric with today.

## Architecture / persistence shape

```ts
export interface StoryQuizHistoryEntry {
  readonly id: string;          // generated INSIDE addStoryQuizResult; callers don't pass it
  readonly date: string;        // ISO timestamp; generated inside the hook
  readonly storySlug: string;
  readonly storyTitle: string;  // snapshotted
  readonly correct: number;
  readonly total: number;
}
```

New hook surface on `useProgress`: `addStoryQuizResult({ storySlug, storyTitle, correct, total })`, `removeStoryQuizResult(id)`, `restoreStoryQuizResult(entry)`, `clearStoryQuizHistory()`.

Persisted array order is **not** semantically meaningful — every view sorts by `date` (or derived `lastAttemptAt`) at render time. This means the undo flow can re-insert a deleted entry anywhere and the chronological/aggregation views still place it correctly without insert-at-index logic.

## Phase plan executed

Per [issue #85's locked plan](https://github.com/henrik-me/NaturalizationPuzzle/issues/85), the work was split across 5 phases with parallel sub-agents in isolated worktrees:

1. Phase 2 (foundation: `useProgress` hook + persistence shape + migration) — single sub-agent.
2. Phase 3 (parallel) — Stream A on `StoryPage` + Stream B on `HistoryPage` + `storyStats` helper, in disjoint file allowlists.
3. Phase 3.5 (orchestrator) — README updates folded into this PR (Routes, Story Mode, Study Progress, Data Storage).
4. Phase 4 — single sub-agent for the Playwright pass.
5. Phase 5 (parallel) — verify-prepush full sweep + GPT-5.5 final-diff review. Round 1 caught a per-row a11y gap in the results review (icon-only correctness indicator); round-2 fix added `sr-only` "Correct"/"Incorrect" labels to the StoryPage results review **and** to the existing analogous QuizPage results review (audit-whole-file). Round 2 of both gates: PASS / CLEAN.

## Verification

- `client`: lint OK, 205/205 tests, build OK
- `api`: build OK, 152/152 tests
- `e2e`: 39/39 tests (Playwright `--reporter=list`)
- GPT-5.5 final-diff review: CLEAN on round 2

## Locked decisions

The full A–S decision table lives in the issue body. Most user-visible:

- Two-CTA chooser, no default. Choice is committed by clicking either button.
- Per-question feedback after each Submit (green/red with accepted answers visible).
- No pass/fail thresholds; no early stop.
- Scored attempts kept in their own `storyQuizHistory` array, separate from `quizHistory`.
- Story Comprehension block placed BELOW existing "All Attempts" on the History page.
- × delete is immediate with ~7s inline Undo (latest-only undoable; cleared on unmount/navigate/clear).

## Out of scope (intentional)

- Adding × delete + undo to the existing /quiz history rows (separate concern; tracked as a follow-up consideration).
- Per-story 65/20 mode and reading/writing vocabulary practice (CONTEXT.md items #16 and #17).

Closes #85.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
