### PR TITLE
perf(api): response compression + AsNoTracking + StateService projection

### DIFF
--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -43,7 +43,13 @@ builder.Services.AddResponseCompression(options =>
     options.EnableForHttps = true;
     options.Providers.Add<BrotliCompressionProvider>();
     options.Providers.Add<GzipCompressionProvider>();
-    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(["application/json"]);
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat([
+        "application/json",
+        // ProblemDetails (RFC 9457) responses emitted by GlobalExceptionHandler
+        // and Results.ValidationProblem() use this MIME type; without it,
+        // error payloads would not be compressed.
+        "application/problem+json",
+    ]);
 });
 builder.Services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
 builder.Services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);

--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -1,4 +1,6 @@
+using System.IO.Compression;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using NaturalizationPuzzle.Api.Data;
 using NaturalizationPuzzle.Api.Endpoints;
@@ -28,6 +30,24 @@ builder.Services.AddProblemDetails();
 builder.Services.Configure<ExceptionLoggingOptions>(
     builder.Configuration.GetSection(ExceptionLoggingOptions.SectionName));
 
+// Response compression for JSON API payloads. The largest endpoint
+// (/api/v1/questions) returns the full 128-question pool with tags + answers
+// and benefits substantially from Brotli/Gzip. SAFETY: EnableForHttps opts in
+// to compression over TLS — this is normally avoided due to CRIME/BREACH-class
+// attacks, but the threat model does not apply here: responses are public
+// read-only civics data with no per-user secrets in the body. Compression
+// level Fastest is the sweet spot for on-the-fly API responses (Optimal is
+// ~10x slower for marginal additional size reduction on small JSON).
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(["application/json"]);
+});
+builder.Services.Configure<BrotliCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+builder.Services.Configure<GzipCompressionProviderOptions>(o => o.Level = CompressionLevel.Fastest);
+
 builder.Services.AddOpenApi();
 builder.Services.AddCors(options =>
 {
@@ -53,6 +73,10 @@ if (app.Environment.IsDevelopment())
 {
     app.UseHttpsRedirection();
 }
+
+// Must come before UseStaticFiles and endpoint mapping so it can compress
+// both static-file responses and API responses on the way out.
+app.UseResponseCompression();
 
 app.UseDefaultFiles();
 app.UseStaticFiles();

--- a/src/api/Services/QuestionService.cs
+++ b/src/api/Services/QuestionService.cs
@@ -9,17 +9,12 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
     public async Task<IReadOnlyList<QuestionDto>> GetAllQuestionsAsync(int? stateId, CancellationToken cancellationToken)
     {
         var questions = await db.Questions
+            .AsNoTracking()
             .Include(q => q.Answers)
             .OrderBy(q => q.Id)
             .ToListAsync(cancellationToken);
 
-        var state = stateId.HasValue
-            ? await db.States.FindAsync([stateId.Value], cancellationToken)
-            : null;
-
-        var representatives = stateId.HasValue
-            ? await db.Representatives.Where(r => r.StateId == stateId.Value).ToListAsync(cancellationToken)
-            : [];
+        var (state, representatives) = await LoadStateContextAsync(stateId, cancellationToken);
 
         return questions.Select(q => MapToDto(q, state, representatives)).ToList();
     }
@@ -27,18 +22,13 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
     public async Task<QuestionDto?> GetQuestionByIdAsync(int id, int? stateId, CancellationToken cancellationToken)
     {
         var question = await db.Questions
+            .AsNoTracking()
             .Include(q => q.Answers)
             .FirstOrDefaultAsync(q => q.Id == id, cancellationToken);
 
         if (question is null) return null;
 
-        var state = stateId.HasValue
-            ? await db.States.FindAsync([stateId.Value], cancellationToken)
-            : null;
-
-        var representatives = stateId.HasValue
-            ? await db.Representatives.Where(r => r.StateId == stateId.Value).ToListAsync(cancellationToken)
-            : [];
+        var (state, representatives) = await LoadStateContextAsync(stateId, cancellationToken);
 
         return MapToDto(question, state, representatives);
     }
@@ -46,18 +36,13 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
     public async Task<IReadOnlyList<QuestionDto>> GetQuestionsByCategoryAsync(string category, int? stateId, CancellationToken cancellationToken)
     {
         var questions = await db.Questions
+            .AsNoTracking()
             .Include(q => q.Answers)
             .Where(q => q.Category == category)
             .OrderBy(q => q.Id)
             .ToListAsync(cancellationToken);
 
-        var state = stateId.HasValue
-            ? await db.States.FindAsync([stateId.Value], cancellationToken)
-            : null;
-
-        var representatives = stateId.HasValue
-            ? await db.Representatives.Where(r => r.StateId == stateId.Value).ToListAsync(cancellationToken)
-            : [];
+        var (state, representatives) = await LoadStateContextAsync(stateId, cancellationToken);
 
         return questions.Select(q => MapToDto(q, state, representatives)).ToList();
     }
@@ -65,18 +50,13 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
     public async Task<IReadOnlyList<QuestionDto>> Get6520QuestionsAsync(int? stateId, CancellationToken cancellationToken)
     {
         var questions = await db.Questions
+            .AsNoTracking()
             .Include(q => q.Answers)
             .Where(q => q.Is6520Designated)
             .OrderBy(q => q.Id)
             .ToListAsync(cancellationToken);
 
-        var state = stateId.HasValue
-            ? await db.States.FindAsync([stateId.Value], cancellationToken)
-            : null;
-
-        var representatives = stateId.HasValue
-            ? await db.Representatives.Where(r => r.StateId == stateId.Value).ToListAsync(cancellationToken)
-            : [];
+        var (state, representatives) = await LoadStateContextAsync(stateId, cancellationToken);
 
         return questions.Select(q => MapToDto(q, state, representatives)).ToList();
     }
@@ -90,17 +70,12 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
 
         var idSet = ids.ToHashSet();
         var questions = await db.Questions
+            .AsNoTracking()
             .Include(q => q.Answers)
             .Where(q => idSet.Contains(q.Id))
             .ToListAsync(cancellationToken);
 
-        var state = stateId.HasValue
-            ? await db.States.FindAsync([stateId.Value], cancellationToken)
-            : null;
-
-        var representatives = stateId.HasValue
-            ? await db.Representatives.Where(r => r.StateId == stateId.Value).ToListAsync(cancellationToken)
-            : [];
+        var (state, representatives) = await LoadStateContextAsync(stateId, cancellationToken);
 
         var byId = questions.ToDictionary(q => q.Id, q => MapToDto(q, state, representatives));
         var ordered = new List<QuestionDto>(ids.Count);
@@ -112,6 +87,30 @@ public sealed class QuestionService(AppDbContext db) : IQuestionService
             }
         }
         return ordered;
+    }
+
+    // Loads the optional state + its representatives for state-specific answer
+    // resolution. Both lookups are read-only and use AsNoTracking to avoid
+    // populating the change tracker on hot read paths.
+    private async Task<(UsState? state, IReadOnlyList<Representative> reps)> LoadStateContextAsync(
+        int? stateId, CancellationToken cancellationToken)
+    {
+        if (!stateId.HasValue)
+        {
+            return (null, []);
+        }
+
+        var state = await db.States
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == stateId.Value, cancellationToken);
+
+        var reps = await db.Representatives
+            .AsNoTracking()
+            .Where(r => r.StateId == stateId.Value)
+            .OrderBy(r => r.Id)
+            .ToListAsync(cancellationToken);
+
+        return (state, reps);
     }
 
     private static QuestionDto MapToDto(Question question, UsState? state, IReadOnlyList<Representative> representatives)

--- a/src/api/Services/QuizService.cs
+++ b/src/api/Services/QuizService.cs
@@ -30,6 +30,7 @@ public sealed class QuizService(AppDbContext db) : IQuizService
     public async Task<QuizResultDto?> GetQuizResultAsync(string sessionId, CancellationToken cancellationToken)
     {
         var session = await db.QuizSessions
+            .AsNoTracking()
             .FirstOrDefaultAsync(s => s.SessionId == sessionId, cancellationToken);
 
         return session is null ? null : MapToDto(session);

--- a/src/api/Services/RepresentativeService.cs
+++ b/src/api/Services/RepresentativeService.cs
@@ -9,8 +9,8 @@ public sealed class RepresentativeService(AppDbContext db) : IRepresentativeServ
     public async Task<IReadOnlyList<VacantSeatDto>> GetVacantSeatsAsync(CancellationToken cancellationToken)
     {
         return await (
-            from r in db.Representatives
-            join s in db.States on r.StateId equals s.Id
+            from r in db.Representatives.AsNoTracking()
+            join s in db.States.AsNoTracking() on r.StateId equals s.Id
             where r.Name == "Vacant"
             orderby s.Name, r.District
             select new VacantSeatDto(r.Id, r.StateId, s.Name, r.District)
@@ -20,8 +20,8 @@ public sealed class RepresentativeService(AppDbContext db) : IRepresentativeServ
     public async Task<IReadOnlyList<VacantSeatDto>> GetVacantSeatsByStateAsync(int stateId, CancellationToken cancellationToken)
     {
         return await (
-            from r in db.Representatives
-            join s in db.States on r.StateId equals s.Id
+            from r in db.Representatives.AsNoTracking()
+            join s in db.States.AsNoTracking() on r.StateId equals s.Id
             where r.StateId == stateId && r.Name == "Vacant"
             orderby r.District
             select new VacantSeatDto(r.Id, r.StateId, s.Name, r.District)

--- a/src/api/Services/StateService.cs
+++ b/src/api/Services/StateService.cs
@@ -8,35 +8,47 @@ public sealed class StateService(AppDbContext db) : IStateService
 {
     public async Task<IReadOnlyList<UsStateDto>> GetAllStatesAsync(CancellationToken cancellationToken)
     {
-        var states = await db.States
+        // Single server-side projection: replaces the previous "load all states +
+        // load all representatives + in-memory filter" pattern. The inner OrderBy
+        // by Representative.Id preserves the historical insertion ordering that
+        // the legacy in-memory filter inherited from the unordered ToListAsync().
+        return await db.States
+            .AsNoTracking()
             .OrderBy(s => s.Name)
+            .Select(s => new UsStateDto(
+                s.Id,
+                s.Name,
+                s.Abbreviation,
+                s.Capital,
+                s.Governor,
+                s.SenatorOne,
+                s.SenatorTwo,
+                db.Representatives
+                    .Where(r => r.StateId == s.Id)
+                    .OrderBy(r => r.Id)
+                    .Select(r => r.Name)
+                    .ToList()))
             .ToListAsync(cancellationToken);
-
-        var representatives = await db.Representatives
-            .ToListAsync(cancellationToken);
-
-        return states.Select(s => MapToDto(s, representatives.Where(r => r.StateId == s.Id).ToList())).ToList();
     }
 
     public async Task<UsStateDto?> GetStateByIdAsync(int id, CancellationToken cancellationToken)
     {
-        var state = await db.States.FindAsync([id], cancellationToken);
-        if (state is null) return null;
-
-        var reps = await db.Representatives
-            .Where(r => r.StateId == id)
-            .ToListAsync(cancellationToken);
-
-        return MapToDto(state, reps);
+        return await db.States
+            .AsNoTracking()
+            .Where(s => s.Id == id)
+            .Select(s => new UsStateDto(
+                s.Id,
+                s.Name,
+                s.Abbreviation,
+                s.Capital,
+                s.Governor,
+                s.SenatorOne,
+                s.SenatorTwo,
+                db.Representatives
+                    .Where(r => r.StateId == s.Id)
+                    .OrderBy(r => r.Id)
+                    .Select(r => r.Name)
+                    .ToList()))
+            .FirstOrDefaultAsync(cancellationToken);
     }
-
-    private static UsStateDto MapToDto(UsState state, IReadOnlyList<Representative> representatives) => new(
-        state.Id,
-        state.Name,
-        state.Abbreviation,
-        state.Capital,
-        state.Governor,
-        state.SenatorOne,
-        state.SenatorTwo,
-        representatives.Select(r => r.Name).ToList());
 }

--- a/src/api/Services/StateService.cs
+++ b/src/api/Services/StateService.cs
@@ -6,49 +6,30 @@ namespace NaturalizationPuzzle.Api.Services;
 
 public sealed class StateService(AppDbContext db) : IStateService
 {
-    public async Task<IReadOnlyList<UsStateDto>> GetAllStatesAsync(CancellationToken cancellationToken)
-    {
-        // Single server-side projection: replaces the previous "load all states +
-        // load all representatives + in-memory filter" pattern. The inner OrderBy
-        // by Representative.Id preserves the historical insertion ordering that
-        // the legacy in-memory filter inherited from the unordered ToListAsync().
-        return await db.States
-            .AsNoTracking()
-            .OrderBy(s => s.Name)
-            .Select(s => new UsStateDto(
-                s.Id,
-                s.Name,
-                s.Abbreviation,
-                s.Capital,
-                s.Governor,
-                s.SenatorOne,
-                s.SenatorTwo,
-                db.Representatives
-                    .Where(r => r.StateId == s.Id)
-                    .OrderBy(r => r.Id)
-                    .Select(r => r.Name)
-                    .ToList()))
+    public async Task<IReadOnlyList<UsStateDto>> GetAllStatesAsync(CancellationToken cancellationToken) =>
+        await ProjectToDto(db.States.AsNoTracking().OrderBy(s => s.Name))
             .ToListAsync(cancellationToken);
-    }
 
-    public async Task<UsStateDto?> GetStateByIdAsync(int id, CancellationToken cancellationToken)
-    {
-        return await db.States
-            .AsNoTracking()
-            .Where(s => s.Id == id)
-            .Select(s => new UsStateDto(
-                s.Id,
-                s.Name,
-                s.Abbreviation,
-                s.Capital,
-                s.Governor,
-                s.SenatorOne,
-                s.SenatorTwo,
-                db.Representatives
-                    .Where(r => r.StateId == s.Id)
-                    .OrderBy(r => r.Id)
-                    .Select(r => r.Name)
-                    .ToList()))
+    public async Task<UsStateDto?> GetStateByIdAsync(int id, CancellationToken cancellationToken) =>
+        await ProjectToDto(db.States.AsNoTracking().Where(s => s.Id == id))
             .FirstOrDefaultAsync(cancellationToken);
-    }
+
+    // Shared server-side projection: a single SQL statement loads each state with
+    // its representatives via a correlated subquery. The inner OrderBy(r => r.Id)
+    // pins a stable, deterministic ordering for the rep name list so downstream
+    // UI/tests don't depend on the database's unspecified default row order.
+    private IQueryable<UsStateDto> ProjectToDto(IQueryable<UsState> source) =>
+        source.Select(s => new UsStateDto(
+            s.Id,
+            s.Name,
+            s.Abbreviation,
+            s.Capital,
+            s.Governor,
+            s.SenatorOne,
+            s.SenatorTwo,
+            db.Representatives
+                .Where(r => r.StateId == s.Id)
+                .OrderBy(r => r.Id)
+                .Select(r => r.Name)
+                .ToList()));
 }

--- a/tests/api/StateServiceTests.cs
+++ b/tests/api/StateServiceTests.cs
@@ -41,7 +41,10 @@ public sealed class StateServiceTests : IDisposable
 
         Assert.NotEmpty(states);
         var names = states.Select(s => s.Name).ToList();
-        Assert.Equal(names.OrderBy(n => n).ToList(), names);
+        // SQLite's default TEXT collation is BINARY (ordinal byte comparison),
+        // so the assertion must use StringComparer.Ordinal to match what the
+        // service's ORDER BY actually produces — not LINQ's current-culture default.
+        Assert.Equal(names.OrderBy(n => n, StringComparer.Ordinal).ToList(), names);
     }
 
     [Fact]

--- a/tests/api/StateServiceTests.cs
+++ b/tests/api/StateServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using NaturalizationPuzzle.Api.Data;
 using NaturalizationPuzzle.Api.Models;
@@ -5,15 +6,27 @@ using NaturalizationPuzzle.Api.Services;
 
 namespace NaturalizationPuzzle.Api.Tests;
 
+/// <summary>
+/// SQLite-backed tests for <see cref="StateService"/>. The service uses a
+/// correlated subquery inside a projection (see <c>GetAllStatesAsync</c>),
+/// which the EF InMemory provider would not actually validate against real
+/// SQL translation. Using SQLite in-memory (matching the
+/// <c>QuestionTagsPersistenceTests</c> pattern) ensures the query both
+/// translates and executes correctly against the same provider production uses.
+/// </summary>
 public sealed class StateServiceTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly AppDbContext _db;
     private readonly StateService _sut;
 
     public StateServiceTests()
     {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
         var options = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
 
         _db = new AppDbContext(options);
@@ -49,23 +62,24 @@ public sealed class StateServiceTests : IDisposable
         var states = await _sut.GetAllStatesAsync(CancellationToken.None);
         var california = states.First(s => s.Abbreviation == "CA");
 
-        var caRepIds = await _db.Representatives
+        var caRepNames = await _db.Representatives
             .Where(r => r.StateId == california.Id)
             .OrderBy(r => r.Id)
             .Select(r => r.Name)
             .ToListAsync();
 
-        Assert.Equal(caRepIds, california.Representatives);
+        Assert.Equal(caRepNames, california.Representatives);
     }
 
     [Fact]
     public async Task GetAllStatesAsync_ReturnsRepresentativesInIdOrder_EvenWhenInsertedOutOfOrder()
     {
-        // Seed a synthetic state with representatives inserted in a deliberately
-        // non-ascending Id order. If the projection's inner OrderBy(r => r.Id) is
-        // ever removed, the InMemory provider would return reps in insertion
-        // order and this assertion would fail. Anchors the ordering contract
-        // independently of the seed data's coincidental Id-ordered layout.
+        // Seed a synthetic state with representatives inserted in deliberately
+        // non-ascending Id order. Without the projection's inner OrderBy(r => r.Id),
+        // SQLite's default row ordering for an unindexed correlated subquery is
+        // not guaranteed to be ascending by Id, so removing the OrderBy would
+        // surface here. Anchors the ordering contract independently of any
+        // coincidental Id-ordered layout in the seed data.
         const int syntheticStateId = 9001;
         _db.States.Add(new UsState
         {
@@ -84,7 +98,8 @@ public sealed class StateServiceTests : IDisposable
             new Representative { Id = 9015, StateId = syntheticStateId, District = "2", Name = "Rep Bravo" });
         await _db.SaveChangesAsync();
 
-        var state = await _sut.GetStateByIdAsync(syntheticStateId, CancellationToken.None);
+        var allStates = await _sut.GetAllStatesAsync(CancellationToken.None);
+        var state = allStates.FirstOrDefault(s => s.Abbreviation == "ZZ");
 
         Assert.NotNull(state);
         Assert.Equal(new[] { "Rep Alpha", "Rep Bravo", "Rep Charlie" }, state!.Representatives);
@@ -109,5 +124,9 @@ public sealed class StateServiceTests : IDisposable
         Assert.Null(fetched);
     }
 
-    public void Dispose() => _db.Dispose();
+    public void Dispose()
+    {
+        _db.Dispose();
+        _connection.Dispose();
+    }
 }

--- a/tests/api/StateServiceTests.cs
+++ b/tests/api/StateServiceTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.EntityFrameworkCore;
+using NaturalizationPuzzle.Api.Data;
+using NaturalizationPuzzle.Api.Models;
+using NaturalizationPuzzle.Api.Services;
+
+namespace NaturalizationPuzzle.Api.Tests;
+
+public sealed class StateServiceTests : IDisposable
+{
+    private readonly AppDbContext _db;
+    private readonly StateService _sut;
+
+    public StateServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _db = new AppDbContext(options);
+        _db.Database.EnsureCreated();
+        _sut = new StateService(_db);
+    }
+
+    [Fact]
+    public async Task GetAllStatesAsync_ReturnsAllStates_OrderedByName()
+    {
+        var states = await _sut.GetAllStatesAsync(CancellationToken.None);
+
+        Assert.NotEmpty(states);
+        var names = states.Select(s => s.Name).ToList();
+        Assert.Equal(names.OrderBy(n => n).ToList(), names);
+    }
+
+    [Fact]
+    public async Task GetAllStatesAsync_PopulatesRepresentativesForEachState()
+    {
+        var states = await _sut.GetAllStatesAsync(CancellationToken.None);
+
+        // Every seeded state has at least one representative (at-large or otherwise).
+        Assert.All(states, s => Assert.NotEmpty(s.Representatives));
+    }
+
+    [Fact]
+    public async Task GetAllStatesAsync_ReturnsRepresentativesInIdOrder()
+    {
+        // The legacy implementation loaded all representatives and filtered by stateId
+        // in memory; that produced reps in insertion (Id) order. The refactored
+        // implementation must preserve that ordering so downstream UI/tests stay stable.
+        var states = await _sut.GetAllStatesAsync(CancellationToken.None);
+        var california = states.First(s => s.Abbreviation == "CA");
+
+        var caRepIds = await _db.Representatives
+            .Where(r => r.StateId == california.Id)
+            .OrderBy(r => r.Id)
+            .Select(r => r.Name)
+            .ToListAsync();
+
+        Assert.Equal(caRepIds, california.Representatives);
+    }
+
+    [Fact]
+    public async Task GetAllStatesAsync_ReturnsRepresentativesInIdOrder_EvenWhenInsertedOutOfOrder()
+    {
+        // Seed a synthetic state with representatives inserted in a deliberately
+        // non-ascending Id order. If the projection's inner OrderBy(r => r.Id) is
+        // ever removed, the InMemory provider would return reps in insertion
+        // order and this assertion would fail. Anchors the ordering contract
+        // independently of the seed data's coincidental Id-ordered layout.
+        const int syntheticStateId = 9001;
+        _db.States.Add(new UsState
+        {
+            Id = syntheticStateId,
+            Name = "ZZ Test State",
+            Abbreviation = "ZZ",
+            Capital = "Testopolis",
+            Governor = "Test Governor",
+            SenatorOne = "Test Senator A",
+            SenatorTwo = "Test Senator B",
+            Representative = "Test Rep",
+        });
+        _db.Representatives.AddRange(
+            new Representative { Id = 9020, StateId = syntheticStateId, District = "3", Name = "Rep Charlie" },
+            new Representative { Id = 9010, StateId = syntheticStateId, District = "1", Name = "Rep Alpha" },
+            new Representative { Id = 9015, StateId = syntheticStateId, District = "2", Name = "Rep Bravo" });
+        await _db.SaveChangesAsync();
+
+        var state = await _sut.GetStateByIdAsync(syntheticStateId, CancellationToken.None);
+
+        Assert.NotNull(state);
+        Assert.Equal(new[] { "Rep Alpha", "Rep Bravo", "Rep Charlie" }, state!.Representatives);
+    }
+
+    [Fact]
+    public async Task GetStateByIdAsync_ReturnsState_WhenExists()
+    {
+        var first = (await _sut.GetAllStatesAsync(CancellationToken.None)).First();
+        var fetched = await _sut.GetStateByIdAsync(first.Id, CancellationToken.None);
+
+        Assert.NotNull(fetched);
+        Assert.Equal(first.Name, fetched.Name);
+        Assert.Equal(first.Capital, fetched.Capital);
+        Assert.Equal(first.Representatives, fetched.Representatives);
+    }
+
+    [Fact]
+    public async Task GetStateByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var fetched = await _sut.GetStateByIdAsync(99999, CancellationToken.None);
+        Assert.Null(fetched);
+    }
+
+    public void Dispose() => _db.Dispose();
+}


### PR DESCRIPTION
## Summary

Three backend perf fixes from the baseline audit, landed as one focused PR. No frontend changes.

### 1. Response compression (Brotli + Gzip)

Adds `UseResponseCompression` middleware at `CompressionLevel.Fastest`. JSON is added to the MIME-type list so the largest payload (`/api/v1/questions` with the full 128-question pool + tags + answers) compresses on the wire. The Docker container talks Kestrel directly on port 8080 and Azure App Service for Linux containers does not auto-compress, so this is a real win at the edge.

**Safety:** `EnableForHttps = true` is opted in despite the default-off CRIME/BREACH stance. Responses are public read-only civics data with no per-user secrets in the body, so the side-channel threat model does not apply. Rationale documented inline.

### 2. AsNoTracking on read-only EF queries

Read paths in `QuestionService` (5 methods + new `LoadStateContextAsync` helper), `QuizService.GetQuizResultAsync`, and `RepresentativeService.GetVacantSeats*` no longer populate the change tracker. Mutation paths (`UpdateRepresentativeAsync`, `ResetToSeedDataAsync`) intentionally untouched.

The helper extracts the duplicated state+reps lookup blocks in `QuestionService` and replaces `FindAsync` with `AsNoTracking().FirstOrDefaultAsync` (since `FindAsync` cannot combine with `AsNoTracking`).

### 3. StateService → single-query projection

`GetAllStatesAsync` previously loaded every state, then every representative, then matched reps to states in memory (O(states × reps) after two round trips). Replaced with a single EF projection using a correlated subquery, with `.OrderBy(r => r.Id)` inside the inner select to preserve the legacy insertion-order behavior.

Adds `StateServiceTests` (none existed). The representative-ordering test seeds a synthetic state with reps inserted in non-ascending Id order, so removing the inner `OrderBy` would actually fail the assertion (not just coincidentally pass).

## Out of scope

- **Cache-Control on `/questions` and `/stories`** — initially planned, dropped during GPT-5.5 plan review. Those endpoints embed editable rep names via `ResolveStateAnswers` (question 29) and the state-aware story preamble. A 120s `max-age` would delay rep edits surfacing for up to 2 minutes. The SW already wraps these in StaleWhileRevalidate, so the marginal browser-HTTP-cache win was not worth the correctness risk. Deferred to a future PR.
- Frontend optimizations (code splitting, etc.) — separate PRs.

## Verification

Pre-push verification ran in a dedicated worktree:

- API: build OK, tests 157/157
- Client: lint OK, tests 209/209, build OK
- E2E: 39/39

Final-diff GPT-5.5 review: 1 minor finding (ordering test seed was coincidentally in Id order under InMemory provider) — addressed by adding a synthetic state with reps inserted out of order.

## Commits

- `perf(api): enable Brotli + Gzip response compression`
- `perf(api): collapse StateService into single-query projections`
- `perf(api): apply AsNoTracking() to read-only EF queries`
