### PR TITLE
feat(ci): add Container E2E (Playwright) CI job (Stream C of #20)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -433,6 +433,98 @@ jobs:
         if: always()
         run: docker rm -f smoke || true
 
+  container-e2e:
+    name: Container E2E (Playwright)
+    needs: docker-build-push
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Install e2e dependencies
+        working-directory: tests/e2e
+        run: npm ci
+
+      - name: Install Playwright browser (chromium)
+        working-directory: tests/e2e
+        run: npx playwright install --with-deps chromium
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and run image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.docker-build-push.outputs.image-tag }}
+        run: |
+          set -euo pipefail
+          echo "Pulling image: $IMAGE"
+          docker pull "$IMAGE"
+          docker run -d --name e2e-container -p 8080:8080 \
+            -e ASPNETCORE_ENVIRONMENT=Production \
+            "$IMAGE"
+
+      - name: Wait for /api/health
+        run: |
+          set -euo pipefail
+          # 60 retries chosen over image-smoke-test's 30 because container-e2e
+          # also has Playwright bootstrap running on the same runner; budget
+          # extra margin for cold-start contention. Stream A bumped local
+          # webServer timeout to 120s for the same reason.
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/api/health >/tmp/health.json 2>/dev/null \
+              && jq -e '.status == "healthy" and .database == true and .questionCount > 0' /tmp/health.json >/dev/null; then
+              echo "Healthy after ${i}s:"
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Health check did not succeed within 60s"
+          docker logs e2e-container || true
+          exit 1
+
+      - name: Run Playwright suite against container
+        working-directory: tests/e2e
+        env:
+          PLAYWRIGHT_BASE_URL: http://localhost:8080
+        # PLAYWRIGHT_BASE_URL is honored by playwright.config.ts (Stream A
+        # of #20): when set, the dev-stack webServer blocks are skipped and
+        # tests target the external URL — here, the production Docker image.
+        run: npx playwright test --reporter=list
+
+      - name: Capture container logs on failure
+        if: failure()
+        run: docker logs --tail 500 e2e-container || true
+
+      - name: Upload Playwright test results
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: container-e2e-playwright-results
+          path: tests/e2e/test-results/
+          retention-days: 14
+
+      - name: Tear down container
+        if: always()
+        run: docker rm -f e2e-container || true
+
   detect-changes:
     name: Detect deployable changes
     needs: [build-and-test, e2e, lighthouse]
@@ -496,7 +588,7 @@ jobs:
 
   deploy-apply:
     name: Deploy Apply (gated)
-    needs: [docker-build-push, deploy-plan, detect-changes]
+    needs: [docker-build-push, deploy-plan, detect-changes, container-e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.detect-changes.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Stream C of #20 — Containerized Playwright E2E in CI

Adds a new `Container E2E (Playwright)` CI job that runs the full Playwright suite against the **production Docker image** pulled from GHCR, then gates production deploy on its success. This is the CI counterpart to the local reproducer scripts from PR #111 (Stream B) and consumes the `PLAYWRIGHT_BASE_URL` plumbing from PR #110 (Stream A).

### Why

The pre-existing dev-stack E2E job (`e2e` / `E2E (Playwright)`) starts Vite + `dotnet run` via Playwright's `webServer` config. That misses an entire class of bugs that only manifest when running the production-built image — most notably the [PR #81 silent-empty-stories incident](https://github.com/henrik-me/NaturalizationPuzzle/pull/81), where embedded resources were excluded from the Docker build context. The dev-stack tests passed; production was broken.

This job closes that gap by:
1. Pulling the exact image that will be deployed (`docker pull "$IMAGE"`).
2. Running the production binary in `Production` ASPNETCORE_ENVIRONMENT.
3. Waiting for `/api/health` to report healthy + database connected + question count > 0 (same gate as `image-smoke-test`).
4. Running the full Playwright suite against `http://localhost:8080` (the container) via `PLAYWRIGHT_BASE_URL`.
5. Gating `deploy-apply` so a failing image-driven E2E blocks production deploy.

### Changes

- `.github/workflows/ci-cd.yml`:
  - New `container-e2e` job (after `image-smoke-test`).
    - `needs: docker-build-push` (pulls the image it produced).
    - `if: github.event_name == 'push'` (matches the other image-touching jobs).
    - 60s health-check loop (vs `image-smoke-test`'s 30s — Playwright bootstrap is competing for runner I/O, matches the Stream A 30s→120s webServer timeout bump).
    - `npm ci` + `npx playwright install --with-deps chromium` for the runner.
    - `PLAYWRIGHT_BASE_URL=http://localhost:8080` makes the dev-stack `webServer` blocks no-op (Stream A behaviour).
    - On failure: `docker logs --tail 500` to job log + upload `tests/e2e/test-results/` (14-day retention).
    - Always: `docker rm -f e2e-container` teardown.
  - `deploy-apply.needs` gains `container-e2e`. The Pre-Merge Checklist already requires CI green; this widens "green" to include the image-driven Playwright run.

### Validation

- **Local YAML parse** of the modified workflow: OK.
- **Full end-to-end CI dry-run** on `tmp/streamc-validate` (a throwaway branch that temporarily added itself to `on.push.branches` so the workflow would trigger): full chain executed including `container-e2e`, job conclusion `success`. Branch has been deleted; the clean PR branch (`feat/container-e2e-ci-job`) does NOT carry the trigger extension.

### Out of scope

- This PR does **NOT** add a post-deploy smoke test against the live Azure Container App. That is tracked separately in #112 (Post-deploy validation for #20) — opened as a follow-up that depends on this PR.

### Closes part of #20

#20 Stream C. With Streams A (#110, merged) + B (#111) + C (this PR), the container-based E2E coverage is complete on the pre-deploy side. The post-deploy live-environment check is the follow-up issue.
