### PR TITLE
fix(answer-checker): accept numeric answers in digit and word form

### DIFF
--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -155,6 +155,13 @@ describe('number/text normalization helpers', () => {
     expect(normalizeNumbers('eighteen seventy')).toBe('1870');
     expect(normalizeNumbers('22nd')).toBe('22');
     expect(normalizeNumbers('fourth')).toBe('fourth');
+    // A lone "hundred" is a plain word, not the number 100.
+    expect(normalizeNumbers('hundred')).toBe('hundred');
+    expect(normalizeNumbers('a hundred')).toBe('a hundred');
+  });
+
+  it('does not accept a lone "hundred" for a hundred-valued answer', () => {
+    expect(checkAnswer('hundred', ['One hundred (100)'])).toBe(false);
   });
 
   it('generateCandidates only emits numeric parenthetical contents', () => {

--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -142,6 +142,18 @@ describe('checkAnswer - numeric false-positive sentinels', () => {
     expect(checkAnswer('Battle of', ['(Battle of) Antietam'])).toBe(false);
   });
 
+  it('does not accept the non-numeric remainder of a numeric answer', () => {
+    expect(checkAnswer('years', ['Four (4) years'])).toBe(false);
+    expect(checkAnswer('states', ['50 states'])).toBe(false);
+    expect(checkAnswer('colonies', ['13 original colonies'])).toBe(false);
+    expect(checkAnswer('original colonies', ['13 original colonies'])).toBe(false);
+    // But supplying the required number (alone or with the noun) still matches.
+    expect(checkAnswer('4', ['Four (4) years'])).toBe(true);
+    expect(checkAnswer('4 years', ['Four (4) years'])).toBe(true);
+    expect(checkAnswer('50', ['50 states'])).toBe(true);
+    expect(checkAnswer('13', ['13 original colonies'])).toBe(true);
+  });
+
   it('preserves non-numeric containment matching', () => {
     expect(checkAnswer('freedom of speech', ['freedom of speech (and of the press)'])).toBe(true);
   });

--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -184,6 +184,24 @@ describe('number/text normalization helpers', () => {
     expect(checkAnswer('hundred', ['One hundred (100)'])).toBe(false);
   });
 
+  it('does not sum unrelated number words into a single cardinal', () => {
+    // "four five" is not a valid cardinal phrase; it must NOT collapse to 9.
+    expect(normalizeNumbers('four five')).toBe('four five');
+    expect(normalizeNumbers('one two')).toBe('one two');
+    expect(normalizeNumbers('nine nine')).toBe('nine nine');
+    expect(normalizeNumbers('one two three')).toBe('one two three');
+    // Valid single groups and spoken-year pairs are still converted.
+    expect(normalizeNumbers('nine')).toBe('9');
+    expect(normalizeNumbers('twenty seven')).toBe('27');
+    expect(normalizeNumbers('nineteen twenty')).toBe('1920');
+  });
+
+  it('does not let summed number words create a false numeric match', () => {
+    expect(checkAnswer('four five', ['Nine (9)'])).toBe(false);
+    expect(checkAnswer('one two', ['Three (3)'])).toBe(false);
+    expect(checkAnswer('nine nine', ['Eighteen (18)'])).toBe(false);
+  });
+
   it('generateCandidates only emits numeric parenthetical contents', () => {
     expect(generateCandidates('Four (4) years')).toContain('4');
     expect(generateCandidates('(Thomas) Jefferson')).not.toContain('Thomas');

--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { checkAnswer, normalizeNumbers, generateCandidates } from './answerChecker';
+import { checkAnswer, __testing__ } from './answerChecker';
+
+const { normalizeNumbers, generateCandidates } = __testing__;
 
 describe('checkAnswer', () => {
   it('matches exact answer (case-insensitive)', () => {
@@ -158,5 +160,14 @@ describe('number/text normalization helpers', () => {
   it('generateCandidates only emits numeric parenthetical contents', () => {
     expect(generateCandidates('Four (4) years')).toContain('4');
     expect(generateCandidates('(Thomas) Jefferson')).not.toContain('Thomas');
+  });
+
+  it('treats prototype-chain keys as plain words, not number words', () => {
+    // `__proto__`, `constructor`, `toString` are inherited Object keys; they must
+    // not be parsed as numbers (would otherwise corrupt normalization).
+    expect(normalizeNumbers('__proto__')).toBe('__proto__');
+    expect(normalizeNumbers('constructor')).toBe('constructor');
+    expect(normalizeNumbers('toString four')).toBe('toString 4');
+    expect(checkAnswer('__proto__', ['Four (4) years'])).toBe(false);
   });
 });

--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { checkAnswer } from './answerChecker';
+import { checkAnswer, normalizeNumbers, generateCandidates } from './answerChecker';
 
 describe('checkAnswer', () => {
   it('matches exact answer (case-insensitive)', () => {
@@ -41,5 +41,122 @@ describe('checkAnswer', () => {
 
   it('matches on significant word overlap', () => {
     expect(checkAnswer('the supreme law of the land', ['the Constitution', 'the supreme law of the land'])).toBe(true);
+  });
+});
+
+describe('checkAnswer - numeric answers (digit and word form)', () => {
+  it('accepts digit, word, and inline forms for "Four (4) years"', () => {
+    const accepted = ['Four (4) years'];
+    expect(checkAnswer('4', accepted)).toBe(true);
+    expect(checkAnswer('four', accepted)).toBe(true);
+    expect(checkAnswer('Four', accepted)).toBe(true);
+    expect(checkAnswer('four years', accepted)).toBe(true);
+    expect(checkAnswer('4 years', accepted)).toBe(true);
+  });
+
+  it('accepts single-digit numeric contents', () => {
+    expect(checkAnswer('9', ['Nine (9)'])).toBe(true);
+    expect(checkAnswer('5', ['Five (5)'])).toBe(true);
+  });
+
+  it('accepts hyphenated and spaced tens words', () => {
+    const accepted = ['Twenty-seven (27)'];
+    expect(checkAnswer('27', accepted)).toBe(true);
+    expect(checkAnswer('twenty-seven', accepted)).toBe(true);
+    expect(checkAnswer('twenty seven', accepted)).toBe(true);
+  });
+
+  it('accepts hundreds', () => {
+    const accepted = ['One hundred (100)'];
+    expect(checkAnswer('100', accepted)).toBe(true);
+    expect(checkAnswer('one hundred', accepted)).toBe(true);
+  });
+
+  it('accepts hundreds with tens and ones', () => {
+    const accepted = ['Four hundred thirty-five (435)'];
+    expect(checkAnswer('435', accepted)).toBe(true);
+    expect(checkAnswer('four hundred thirty-five', accepted)).toBe(true);
+    expect(checkAnswer('four hundred thirty five', accepted)).toBe(true);
+  });
+
+  it('accepts numeric answers embedded in a phrase', () => {
+    expect(checkAnswer('6', ['Six (6) years'])).toBe(true);
+    expect(checkAnswer('six', ['Six (6) years'])).toBe(true);
+    expect(checkAnswer('six years', ['Six (6) years'])).toBe(true);
+    expect(checkAnswer('2', ['Two (2) years'])).toBe(true);
+    expect(checkAnswer('two', ['Two (2) years'])).toBe(true);
+    expect(checkAnswer('2', ['Two (2)'])).toBe(true);
+    expect(checkAnswer('two', ['Two (2)'])).toBe(true);
+  });
+
+  it('accepts a number word inside a longer sentence answer', () => {
+    const accepted = ['Citizens eighteen (18) and older'];
+    expect(checkAnswer('18', accepted)).toBe(true);
+    expect(checkAnswer('eighteen', accepted)).toBe(true);
+  });
+
+  it('accepts numbers with no parenthetical hint', () => {
+    expect(checkAnswer('thirteen', ['13 original colonies'])).toBe(true);
+    expect(checkAnswer('13', ['13 original colonies'])).toBe(true);
+    expect(checkAnswer('fifty', ['50 states'])).toBe(true);
+    expect(checkAnswer('50', ['50 states'])).toBe(true);
+  });
+
+  it('accepts spoken-year pairs', () => {
+    expect(checkAnswer('eighteen seventy', ['1870'])).toBe(true);
+    expect(checkAnswer('1870', ['1870'])).toBe(true);
+    expect(checkAnswer('nineteen twenty', ['1920'])).toBe(true);
+    expect(checkAnswer('1920', ['1920'])).toBe(true);
+    expect(checkAnswer('seventeen seventy six', ['1776'])).toBe(true);
+    expect(checkAnswer('seventeen eighty seven', ['1787'])).toBe(true);
+  });
+});
+
+describe('checkAnswer - numeric false-positive sentinels', () => {
+  it('does not match a digit as a sub-span of a longer number', () => {
+    expect(checkAnswer('1', ['One hundred (100)'])).toBe(false);
+    expect(checkAnswer('3', ['Four hundred thirty-five (435)'])).toBe(false);
+    expect(checkAnswer('4', ['Four hundred thirty-five (435)'])).toBe(false);
+    expect(checkAnswer('13', ['135'])).toBe(false);
+    expect(checkAnswer('2', ['Twenty-seven (27)'])).toBe(false);
+    expect(checkAnswer('5', ['50 states'])).toBe(false);
+    expect(checkAnswer('76', ['1776'])).toBe(false);
+    expect(checkAnswer('76', ['1870'])).toBe(false);
+    expect(checkAnswer('18', ['1870'])).toBe(false);
+  });
+
+  it('does not match wrong single digits', () => {
+    expect(checkAnswer('5', ['Nine (9)'])).toBe(false);
+    expect(checkAnswer('9', ['Five (5)'])).toBe(false);
+  });
+
+  it('does not map word ordinals to digits', () => {
+    expect(checkAnswer('fourth', ['Four (4) years'])).toBe(false);
+  });
+
+  it('does not let non-numeric parenthetical contents satisfy the answer', () => {
+    expect(checkAnswer('Thomas', ['(Thomas) Jefferson'])).toBe(false);
+    expect(checkAnswer('Because of', ['(Because of) the 22nd Amendment'])).toBe(false);
+    expect(checkAnswer('Battle of', ['(Battle of) Antietam'])).toBe(false);
+  });
+
+  it('preserves non-numeric containment matching', () => {
+    expect(checkAnswer('freedom of speech', ['freedom of speech (and of the press)'])).toBe(true);
+  });
+});
+
+describe('number/text normalization helpers', () => {
+  it('normalizeNumbers converts cardinals and ordinals', () => {
+    expect(normalizeNumbers('twenty seven')).toBe('27');
+    expect(normalizeNumbers('four hundred thirty five')).toBe('435');
+    expect(normalizeNumbers('one hundred')).toBe('100');
+    expect(normalizeNumbers('eighteen seventy')).toBe('1870');
+    expect(normalizeNumbers('22nd')).toBe('22');
+    expect(normalizeNumbers('fourth')).toBe('fourth');
+  });
+
+  it('generateCandidates only emits numeric parenthetical contents', () => {
+    expect(generateCandidates('Four (4) years')).toContain('4');
+    expect(generateCandidates('(Thomas) Jefferson')).not.toContain('Thomas');
   });
 });

--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -147,6 +147,26 @@ describe('checkAnswer - numeric false-positive sentinels', () => {
   });
 });
 
+describe('checkAnswer - stopword-only false-positive sentinels', () => {
+  it('does not accept a lone stopword for a multi-word answer', () => {
+    expect(checkAnswer('the', ['the Constitution'])).toBe(false);
+    expect(checkAnswer('the', ['the President'])).toBe(false);
+    expect(checkAnswer('of', ['freedom of speech'])).toBe(false);
+    expect(checkAnswer('and', ['the Senators and the Representatives'])).toBe(false);
+  });
+
+  it('does not accept stopword-only inputs even with multiple stopwords', () => {
+    expect(checkAnswer('the and', ['the Bill of Rights'])).toBe(false);
+    expect(checkAnswer('for the', ['for the people'])).toBe(false);
+  });
+
+  it('still accepts a significant subset of a multi-word answer', () => {
+    expect(checkAnswer('Constitution', ['the Constitution'])).toBe(true);
+    expect(checkAnswer('President', ['the President'])).toBe(true);
+    expect(checkAnswer('speech', ['freedom of speech'])).toBe(true);
+  });
+});
+
 describe('number/text normalization helpers', () => {
   it('normalizeNumbers converts cardinals and ordinals', () => {
     expect(normalizeNumbers('twenty seven')).toBe('27');

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -337,7 +337,10 @@ function containsTokens(haystack: readonly string[], needle: readonly string[]):
  * against the STRIPPED candidate so a parenthetical clarifier (e.g. "(Thomas)")
  * can never satisfy the answer on its own. Stopword-only inputs (e.g. "the")
  * are rejected: significant-word filtering keeps them from matching multi-word
- * answers such as "the Constitution" through containment or overlap.
+ * answers such as "the Constitution" through containment or overlap. For
+ * numeric answers, the lenient paths additionally require the user to supply at
+ * least one of the answer's numeric tokens, so the bare noun ("years",
+ * "states") cannot match "Four (4) years" or "50 states".
  */
 export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string[]): boolean {
   const user = normalizeFull(userAnswer);
@@ -355,20 +358,34 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     if (primary.length === 0) return false;
     const primaryTokens = tokenize(primary);
 
+    // When the canonical answer contains number(s), the user's input must
+    // contain at least one of those exact numeric tokens before the lenient
+    // (reverse-containment / overlap) paths may accept it. This prevents the
+    // non-numeric remainder alone from satisfying a numeric answer, e.g.
+    // "years" must not match "Four (4) years" and "states" must not match
+    // "50 states". (Exact match and forward containment already require the
+    // number to be present, so they are unaffected.)
+    const primaryNumbers = primaryTokens.filter((t) => /^\d+$/.test(t));
+    const userHasRequiredNumber =
+      primaryNumbers.length === 0 || primaryNumbers.some((n) => userTokens.includes(n));
+
     // Whole-token containment in either direction (numeric-safe). The reverse
     // direction (user input is a contiguous subset of the accepted answer) is
-    // only honored when the user typed at least one non-stopword token, so a
-    // lone stopword like "the" cannot match "the Constitution" while a valid
-    // numeric subset like "13" still matches "13 original colonies".
+    // only honored when the user typed at least one non-stopword token (so a
+    // lone stopword like "the" cannot match "the Constitution") and, for
+    // numeric answers, at least one required numeric token.
     if (containsTokens(userTokens, primaryTokens)) return true;
     if (
+      userHasRequiredNumber &&
       userTokens.some((t) => !STOPWORDS.has(t)) &&
       containsTokens(primaryTokens, userTokens)
     ) {
       return true;
     }
 
-    // Significant-word overlap heuristic (>=50% of accepted words present).
+    // Significant-word overlap heuristic (>=50% of accepted words present),
+    // gated on the required numeric token for numeric answers.
+    if (!userHasRequiredNumber) return false;
     const userWords = userTokens.filter(isSignificant);
     const acceptedWords = primaryTokens.filter(isSignificant);
     if (acceptedWords.length === 0) return false;

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -1,42 +1,270 @@
 /**
- * Normalizes text for comparison: lowercase, trim, collapse whitespace,
- * strip parenthetical clarifications and common filler words.
+ * Normalizes free text for comparison (NO parenthetical or number handling):
+ * lowercase, replace every non-word/non-space character (punctuation, hyphens,
+ * parentheses) with a space, collapse runs of whitespace, and trim.
+ *
+ * Parenthetical handling and number normalization are intentionally kept out of
+ * this function and live in `generateCandidates` and `normalizeNumbers` so each
+ * concern stays small and independently testable.
  */
-function normalize(text: string): string {
+export function normalizeText(text: string): string {
   return text
     .toLowerCase()
-    .replace(/\(.*?\)/g, '') // remove parentheticals
-    .replace(/[^\w\s]/g, ' ') // strip punctuation
-    .replace(/\s+/g, ' ')    // collapse whitespace
+    .replace(/[^\w\s]/g, ' ') // strip punctuation/hyphens/parens to spaces
+    .replace(/\s+/g, ' ') // collapse whitespace
     .trim();
+}
+
+const ONES: Readonly<Record<string, number>> = {
+  zero: 0,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+};
+
+const TEENS: Readonly<Record<string, number>> = {
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+};
+
+const TENS: Readonly<Record<string, number>> = {
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fifty: 50,
+  sixty: 60,
+  seventy: 70,
+  eighty: 80,
+  ninety: 90,
+};
+
+function isNumberWord(token: string): boolean {
+  return token in ONES || token in TEENS || token in TENS || token === 'hundred';
+}
+
+function stripOrdinalSuffix(token: string): string {
+  const match = /^(\d+)(?:st|nd|rd|th)$/.exec(token);
+  return match ? match[1] : token;
+}
+
+/**
+ * Splits a run of number words (without "and"/"hundred") into groups, each
+ * representing a value < 100 (a teen, a standalone unit, or a tens word with an
+ * optional trailing unit). Used to detect spoken-year pairs like
+ * "eighteen seventy" (two groups: 18, 70).
+ */
+function splitGroups(tokens: readonly string[]): number[] {
+  const groups: number[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const t = tokens[i];
+    if (t in TEENS) {
+      groups.push(TEENS[t]);
+      i += 1;
+    } else if (t in TENS) {
+      let value = TENS[t];
+      if (i + 1 < tokens.length && tokens[i + 1] in ONES) {
+        value += ONES[tokens[i + 1]];
+        i += 2;
+      } else {
+        i += 1;
+      }
+      groups.push(value);
+    } else if (t in ONES) {
+      groups.push(ONES[t]);
+      i += 1;
+    } else {
+      i += 1;
+    }
+  }
+  return groups;
+}
+
+function parseCardinal(tokens: readonly string[]): number {
+  let current = 0;
+  for (const w of tokens) {
+    if (w === 'and') continue;
+    if (w === 'hundred') {
+      current = (current === 0 ? 1 : current) * 100;
+      continue;
+    }
+    const value = ONES[w] ?? TEENS[w] ?? TENS[w];
+    if (value !== undefined) current += value;
+  }
+  return current;
+}
+
+function convertNumberRun(run: readonly string[]): string {
+  const hasHundred = run.includes('hundred');
+  if (!hasHundred) {
+    const groups = splitGroups(run.filter((t) => t !== 'and'));
+    // Spoken-year pair: two adjacent 2-digit cardinal groups, no hundred/thousand.
+    if (groups.length === 2 && groups.every((g) => g >= 10 && g <= 99)) {
+      return String(groups[0] * 100 + groups[1]);
+    }
+  }
+  return String(parseCardinal(run));
+}
+
+/**
+ * Converts number WORDS to digits via a greedy longest-match phrase pass over
+ * whitespace tokens. Handles:
+ *  - cardinals 0..999 (tens+ones, hundreds with optional "and")
+ *  - 4-digit spoken-year pairs ("eighteen seventy" -> 1870)
+ *  - digit-suffix ordinals ("22nd" -> 22, "4th" -> 4)
+ * Word ordinals ("fourth", "second") are intentionally NOT mapped to digits.
+ * Input is expected to already be `normalizeText`-ed (lowercase, no punctuation,
+ * hyphens already split to spaces). Non-number tokens are left untouched.
+ */
+export function normalizeNumbers(text: string): string {
+  const tokens = text
+    .split(' ')
+    .filter((t) => t.length > 0)
+    .map(stripOrdinalSuffix);
+
+  const result: string[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    if (isNumberWord(tokens[i])) {
+      const run: string[] = [];
+      let j = i;
+      while (j < tokens.length) {
+        if (isNumberWord(tokens[j])) {
+          run.push(tokens[j]);
+          j += 1;
+        } else if (
+          tokens[j] === 'and' &&
+          j + 1 < tokens.length &&
+          isNumberWord(tokens[j + 1])
+        ) {
+          run.push('and');
+          j += 1;
+        } else {
+          break;
+        }
+      }
+      result.push(convertNumberRun(run));
+      i = j;
+    } else {
+      result.push(tokens[i]);
+      i += 1;
+    }
+  }
+  return result.join(' ');
+}
+
+/**
+ * Generates candidate string forms for ONE accepted answer:
+ *  (a) STRIPPED  - parentheses AND their contents removed (the canonical form).
+ *  (b) UNWRAPPED - parentheses removed but their contents kept inline.
+ *  (c) NUMERIC-CONTENTS-ONLY - for each parenthetical whose trimmed content is
+ *      purely numeric, the bare number alone (e.g. "Four (4) years" -> "4").
+ * Non-numeric parenthetical contents never become standalone candidates, so
+ * "(Thomas) Jefferson" does not yield "Thomas". The STRIPPED form is always
+ * returned first (it is the only form used for lenient matching).
+ */
+export function generateCandidates(accepted: string): string[] {
+  const stripped = accepted.replace(/\([^)]*\)/g, ' ');
+  const unwrapped = accepted.replace(/[()]/g, ' ');
+
+  const candidates: string[] = [stripped, unwrapped];
+
+  const parenRegex = /\(([^)]*)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = parenRegex.exec(accepted)) !== null) {
+    const content = match[1].trim();
+    if (/^\d+$/.test(content)) {
+      candidates.push(content);
+    }
+  }
+
+  return [...new Set(candidates)];
+}
+
+function normalizeFull(text: string): string {
+  return normalizeNumbers(normalizeText(text));
+}
+
+function tokenize(text: string): string[] {
+  return text.split(' ').filter((t) => t.length > 0);
+}
+
+/**
+ * Whole-token contiguous containment: true when `needle` appears as a
+ * consecutive run of tokens inside `haystack`. Because matching is per whole
+ * token, a numeric token (e.g. "1") can never match a sub-span of a longer
+ * number (e.g. "100").
+ */
+function containsTokens(haystack: readonly string[], needle: readonly string[]): boolean {
+  if (needle.length === 0 || needle.length > haystack.length) return false;
+  for (let start = 0; start <= haystack.length - needle.length; start += 1) {
+    let all = true;
+    for (let j = 0; j < needle.length; j += 1) {
+      if (haystack[start + j] !== needle[j]) {
+        all = false;
+        break;
+      }
+    }
+    if (all) return true;
+  }
+  return false;
 }
 
 /**
  * Checks whether a user's typed answer matches any of the accepted answers.
- * Uses case-insensitive, normalized substring matching in both directions:
- * the user's answer contains an accepted answer, or vice versa.
+ *
+ * Each accepted answer is expanded into candidate forms (see
+ * `generateCandidates`) and both sides are normalized with `normalizeText`
+ * followed by `normalizeNumbers`, so digit and word number forms are unified
+ * ("four"/"4" -> "4", "twenty-seven"/"27" -> "27", "eighteen seventy"/"1870" ->
+ * "1870"). Matching is numeric-aware: numeric tokens only match by exact whole
+ * token equality, so "1" is never accepted for "100".
+ *
+ * Exact equality is checked against every candidate; lenient matching
+ * (whole-token containment and >=50% significant-word overlap) is applied only
+ * against the STRIPPED candidate so a parenthetical clarifier (e.g. "(Thomas)")
+ * can never satisfy the answer on its own.
  */
 export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string[]): boolean {
-  const normalizedUser = normalize(userAnswer);
-  if (normalizedUser.length === 0) return false;
+  const user = normalizeFull(userAnswer);
+  if (user.length === 0) return false;
+  const userTokens = tokenize(user);
 
-  return acceptedAnswers.some(accepted => {
-    const normalizedAccepted = normalize(accepted);
-    if (normalizedAccepted.length === 0) return false;
+  return acceptedAnswers.some((accepted) => {
+    const candidates = generateCandidates(accepted).map(normalizeFull);
 
-    // Exact match after normalization
-    if (normalizedUser === normalizedAccepted) return true;
+    // Exact match against any candidate form.
+    if (candidates.some((c) => c.length > 0 && c === user)) return true;
 
-    // User answer contains the accepted answer (or vice versa)
-    if (normalizedUser.includes(normalizedAccepted)) return true;
-    if (normalizedAccepted.includes(normalizedUser)) return true;
+    // Lenient matching only against the STRIPPED (canonical) candidate.
+    const primary = candidates[0];
+    if (primary.length === 0) return false;
+    const primaryTokens = tokenize(primary);
 
-    // Check individual words: if user's answer shares 50%+ words with accepted
-    const userWords = normalizedUser.split(' ').filter(w => w.length > 2);
-    const acceptedWords = normalizedAccepted.split(' ').filter(w => w.length > 2);
+    // Whole-token containment in either direction (numeric-safe).
+    if (containsTokens(userTokens, primaryTokens)) return true;
+    if (containsTokens(primaryTokens, userTokens)) return true;
+
+    // Significant-word overlap heuristic (>=50% of accepted words present).
+    const userWords = userTokens.filter((w) => w.length > 2);
+    const acceptedWords = primaryTokens.filter((w) => w.length > 2);
     if (acceptedWords.length === 0) return false;
 
-    const matchingWords = userWords.filter(w => acceptedWords.includes(w));
+    const matchingWords = userWords.filter((w) => acceptedWords.includes(w));
     return matchingWords.length >= Math.ceil(acceptedWords.length * 0.5);
   });
 }

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -7,7 +7,7 @@
  * this function and live in `generateCandidates` and `normalizeNumbers` so each
  * concern stays small and independently testable.
  */
-export function normalizeText(text: string): string {
+function normalizeText(text: string): string {
   return text
     .toLowerCase()
     .replace(/[^\w\s]/g, ' ') // strip punctuation/hyphens/parens to spaces
@@ -52,8 +52,22 @@ const TENS: Readonly<Record<string, number>> = {
   ninety: 90,
 };
 
+/**
+ * Own-property lookup into one of the number-word maps. Avoids the `in`
+ * operator (which walks the prototype chain and would treat inherited keys like
+ * `__proto__`, `constructor`, or `toString` as number words).
+ */
+function numberValue(map: Readonly<Record<string, number>>, token: string): number | undefined {
+  return Object.hasOwn(map, token) ? map[token] : undefined;
+}
+
 function isNumberWord(token: string): boolean {
-  return token in ONES || token in TEENS || token in TENS || token === 'hundred';
+  return (
+    numberValue(ONES, token) !== undefined ||
+    numberValue(TEENS, token) !== undefined ||
+    numberValue(TENS, token) !== undefined ||
+    token === 'hundred'
+  );
 }
 
 function stripOrdinalSuffix(token: string): string {
@@ -72,20 +86,24 @@ function splitGroups(tokens: readonly string[]): number[] {
   let i = 0;
   while (i < tokens.length) {
     const t = tokens[i];
-    if (t in TEENS) {
-      groups.push(TEENS[t]);
+    const teen = numberValue(TEENS, t);
+    const ten = numberValue(TENS, t);
+    const one = numberValue(ONES, t);
+    if (teen !== undefined) {
+      groups.push(teen);
       i += 1;
-    } else if (t in TENS) {
-      let value = TENS[t];
-      if (i + 1 < tokens.length && tokens[i + 1] in ONES) {
-        value += ONES[tokens[i + 1]];
+    } else if (ten !== undefined) {
+      let value = ten;
+      const nextOne = i + 1 < tokens.length ? numberValue(ONES, tokens[i + 1]) : undefined;
+      if (nextOne !== undefined) {
+        value += nextOne;
         i += 2;
       } else {
         i += 1;
       }
       groups.push(value);
-    } else if (t in ONES) {
-      groups.push(ONES[t]);
+    } else if (one !== undefined) {
+      groups.push(one);
       i += 1;
     } else {
       i += 1;
@@ -102,7 +120,7 @@ function parseCardinal(tokens: readonly string[]): number {
       current = (current === 0 ? 1 : current) * 100;
       continue;
     }
-    const value = ONES[w] ?? TEENS[w] ?? TENS[w];
+    const value = numberValue(ONES, w) ?? numberValue(TEENS, w) ?? numberValue(TENS, w);
     if (value !== undefined) current += value;
   }
   return current;
@@ -123,14 +141,14 @@ function convertNumberRun(run: readonly string[]): string {
 /**
  * Converts number WORDS to digits via a greedy longest-match phrase pass over
  * whitespace tokens. Handles:
- *  - cardinals 0..999 (tens+ones, hundreds with optional "and")
+ *  - cardinals: tens + ones, and hundreds with optional "and"
  *  - 4-digit spoken-year pairs ("eighteen seventy" -> 1870)
  *  - digit-suffix ordinals ("22nd" -> 22, "4th" -> 4)
  * Word ordinals ("fourth", "second") are intentionally NOT mapped to digits.
  * Input is expected to already be `normalizeText`-ed (lowercase, no punctuation,
  * hyphens already split to spaces). Non-number tokens are left untouched.
  */
-export function normalizeNumbers(text: string): string {
+function normalizeNumbers(text: string): string {
   const tokens = text
     .split(' ')
     .filter((t) => t.length > 0)
@@ -177,7 +195,7 @@ export function normalizeNumbers(text: string): string {
  * "(Thomas) Jefferson" does not yield "Thomas". The STRIPPED form is always
  * returned first (it is the only form used for lenient matching).
  */
-export function generateCandidates(accepted: string): string[] {
+function generateCandidates(accepted: string): string[] {
   const stripped = accepted.replace(/\([^)]*\)/g, ' ');
   const unwrapped = accepted.replace(/[()]/g, ' ');
 
@@ -268,3 +286,10 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     return matchingWords.length >= Math.ceil(acceptedWords.length * 0.5);
   });
 }
+
+/**
+ * Test-only export of the internal normalization helpers. Production code uses
+ * `checkAnswer` exclusively; these are exposed solely so the unit tests can
+ * exercise each pure helper in isolation without widening the public API.
+ */
+export const __testing__ = { normalizeText, normalizeNumbers, generateCandidates };

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -112,16 +112,27 @@ function splitGroups(tokens: readonly string[]): number[] {
   return groups;
 }
 
+/**
+ * Sums a run of cardinal number words into a value. Returns `NaN` when the run
+ * is not a valid standalone cardinal — specifically when "hundred" appears with
+ * no preceding value (a lone "hundred" is a plain word, not the number 100), so
+ * callers leave such tokens unchanged.
+ */
 function parseCardinal(tokens: readonly string[]): number {
   let current = 0;
+  let sawValue = false;
   for (const w of tokens) {
     if (w === 'and') continue;
     if (w === 'hundred') {
-      current = (current === 0 ? 1 : current) * 100;
+      if (!sawValue) return NaN; // lone "hundred" is not a number
+      current *= 100;
       continue;
     }
     const value = numberValue(ONES, w) ?? numberValue(TEENS, w) ?? numberValue(TENS, w);
-    if (value !== undefined) current += value;
+    if (value !== undefined) {
+      current += value;
+      sawValue = true;
+    }
   }
   return current;
 }
@@ -135,7 +146,9 @@ function convertNumberRun(run: readonly string[]): string {
       return String(groups[0] * 100 + groups[1]);
     }
   }
-  return String(parseCardinal(run));
+  const value = parseCardinal(run);
+  // A lone "hundred" (or any run that is not a valid cardinal) is left as words.
+  return Number.isNaN(value) ? run.join(' ') : String(value);
 }
 
 /**

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -235,6 +235,58 @@ function tokenize(text: string): string[] {
 }
 
 /**
+ * Common English function words that carry no civics meaning on their own.
+ * They are excluded from the lenient matching paths so that a stopword-only
+ * input (e.g. "the" or "of") can never satisfy a multi-word answer such as
+ * "the Constitution". Short numbers (e.g. "13") are intentionally NOT stopwords
+ * so a valid numeric subset like "13" still matches "13 original colonies".
+ */
+const STOPWORDS: ReadonlySet<string> = new Set([
+  'a',
+  'an',
+  'as',
+  'at',
+  'be',
+  'by',
+  'do',
+  'he',
+  'in',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'to',
+  'we',
+  'and',
+  'are',
+  'for',
+  'her',
+  'his',
+  'its',
+  'our',
+  'the',
+  'was',
+  'that',
+  'them',
+  'they',
+  'this',
+  'were',
+  'with',
+]);
+
+/**
+ * A token is "significant" for the overlap heuristic if it is long enough to be
+ * meaningful (>2 chars, preserving the prior overlap threshold) and is not a
+ * common stopword. Numeric matching never relies on significance — numbers
+ * match by exact whole-token equality in `containsTokens` and the
+ * exact-equality check.
+ */
+function isSignificant(token: string): boolean {
+  return token.length > 2 && !STOPWORDS.has(token);
+}
+
+/**
  * Whole-token contiguous containment: true when `needle` appears as a
  * consecutive run of tokens inside `haystack`. Because matching is per whole
  * token, a numeric token (e.g. "1") can never match a sub-span of a longer
@@ -268,7 +320,9 @@ function containsTokens(haystack: readonly string[], needle: readonly string[]):
  * Exact equality is checked against every candidate; lenient matching
  * (whole-token containment and >=50% significant-word overlap) is applied only
  * against the STRIPPED candidate so a parenthetical clarifier (e.g. "(Thomas)")
- * can never satisfy the answer on its own.
+ * can never satisfy the answer on its own. Stopword-only inputs (e.g. "the")
+ * are rejected: significant-word filtering keeps them from matching multi-word
+ * answers such as "the Constitution" through containment or overlap.
  */
 export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string[]): boolean {
   const user = normalizeFull(userAnswer);
@@ -286,13 +340,22 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     if (primary.length === 0) return false;
     const primaryTokens = tokenize(primary);
 
-    // Whole-token containment in either direction (numeric-safe).
+    // Whole-token containment in either direction (numeric-safe). The reverse
+    // direction (user input is a contiguous subset of the accepted answer) is
+    // only honored when the user typed at least one non-stopword token, so a
+    // lone stopword like "the" cannot match "the Constitution" while a valid
+    // numeric subset like "13" still matches "13 original colonies".
     if (containsTokens(userTokens, primaryTokens)) return true;
-    if (containsTokens(primaryTokens, userTokens)) return true;
+    if (
+      userTokens.some((t) => !STOPWORDS.has(t)) &&
+      containsTokens(primaryTokens, userTokens)
+    ) {
+      return true;
+    }
 
     // Significant-word overlap heuristic (>=50% of accepted words present).
-    const userWords = userTokens.filter((w) => w.length > 2);
-    const acceptedWords = primaryTokens.filter((w) => w.length > 2);
+    const userWords = userTokens.filter(isSignificant);
+    const acceptedWords = primaryTokens.filter(isSignificant);
     if (acceptedWords.length === 0) return false;
 
     const matchingWords = userWords.filter((w) => acceptedWords.includes(w));

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -137,18 +137,33 @@ function parseCardinal(tokens: readonly string[]): number {
   return current;
 }
 
+/**
+ * Converts a run of number words to its digit string. A run containing
+ * "hundred" is summed as a cardinal (e.g. "four hundred thirty five" -> "435").
+ * A run with no "hundred" is only converted when it forms either (1) a single
+ * value < 100 ("nine" -> "9", "twenty seven" -> "27") or (2) a spoken-year pair
+ * of two 2-digit groups ("eighteen seventy" -> "1870"). Any other no-"hundred"
+ * run (e.g. "four five", "one two three") is NOT a valid cardinal phrase and is
+ * left as words, so unrelated number words can never collapse into a number.
+ */
 function convertNumberRun(run: readonly string[]): string {
-  const hasHundred = run.includes('hundred');
-  if (!hasHundred) {
-    const groups = splitGroups(run.filter((t) => t !== 'and'));
-    // Spoken-year pair: two adjacent 2-digit cardinal groups, no hundred/thousand.
-    if (groups.length === 2 && groups.every((g) => g >= 10 && g <= 99)) {
-      return String(groups[0] * 100 + groups[1]);
-    }
+  if (run.includes('hundred')) {
+    const value = parseCardinal(run);
+    // A lone "hundred" (or any run that is not a valid cardinal) is left as words.
+    return Number.isNaN(value) ? run.join(' ') : String(value);
   }
-  const value = parseCardinal(run);
-  // A lone "hundred" (or any run that is not a valid cardinal) is left as words.
-  return Number.isNaN(value) ? run.join(' ') : String(value);
+
+  const groups = splitGroups(run.filter((t) => t !== 'and'));
+  // Single value < 100: "nine" -> 9, "twenty seven" -> 27.
+  if (groups.length === 1) {
+    return String(groups[0]);
+  }
+  // Spoken-year pair: two adjacent 2-digit groups, e.g. "eighteen seventy" -> 1870.
+  if (groups.length === 2 && groups.every((g) => g >= 10 && g <= 99)) {
+    return String(groups[0] * 100 + groups[1]);
+  }
+  // Not a valid cardinal phrase ("four five", "one two") - leave unchanged.
+  return run.join(' ');
 }
 
 /**

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -396,8 +396,9 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
 }
 
 /**
- * Test-only export of the internal normalization helpers. Production code uses
- * `checkAnswer` exclusively; these are exposed solely so the unit tests can
- * exercise each pure helper in isolation without widening the public API.
+ * Test-only export of the internal normalization helpers, grouped under a
+ * single `__testing__` object rather than exporting each helper individually.
+ * Production code uses `checkAnswer` exclusively; this object exists solely so
+ * the unit tests can exercise each pure helper in isolation.
  */
 export const __testing__ = { normalizeText, normalizeNumbers, generateCandidates };


### PR DESCRIPTION
## Summary

Fixes the typed-answer checker (`src/client/src/utils/answerChecker.ts`) so numeric civics answers are accepted in **both digit and word form**, addressing the most-reported scenarios in #87 (President term `4`, Supreme Court members `9`, justices to decide a case `5`, etc.) without introducing false positives.

Shared by `/quiz` and the Story comprehension quiz — leniency applies uniformly to both.

## What changed

- **`normalizeText`** — text-only normalization (lowercase, punctuation/hyphens→space, collapse, trim). No paren/number handling.
- **`normalizeNumbers`** — greedy longest-match word→digit pass: cardinals 0–999 (hyphenated *and* space-separated), spoken-year pairs (`eighteen seventy`→`1870`), digit-suffix ordinals (`22nd`→`22`). Word ordinals (`fourth`) are intentionally **not** mapped.
- **`generateCandidates`** — expands each accepted answer into stripped / unwrapped / **numeric-contents-only** forms. Non-numeric parentheticals like `(Thomas)` never become standalone candidates.
- **Numeric-aware matcher** — numeric tokens match only by exact **whole-token** equality, so `1` is never accepted for `100`, `5` never for `50 states`, `76` never for `1776`. Lenient matching (whole-token containment + ≥50% word overlap) runs only against the stripped canonical candidate.

## Tests

Added must-pass numeric cases (digit + word forms across Q7/21/22/24/25/27/36/53/54/63, the 13/50 reverse direction, and spoken-year forms) and false-positive sentinels (`1`≠`100`, `3`≠`435`, `13`≠`135`, `5`≠`50 states`, `76`≠`1776`, `fourth`≠`Four (4) years`, `Thomas`≠`(Thomas) Jefferson`, etc.). All pre-existing tests stay green.

- Client: lint clean, all unit tests pass, build + size OK.
- E2E: all Playwright tests pass.

Refs #87 (numeric scenarios S1 + the Q53/Q54 follow-ups). This is the first of three sequential PRs; PR2 (typo tolerance) and PR3 (conservative paraphrase synonyms) follow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
