### PR TITLE
fix: typo tolerance in quiz answer checker (#87)

### DIFF
--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { checkAnswer, __testing__ } from './answerChecker';
 
-const { normalizeNumbers, generateCandidates } = __testing__;
+const { normalizeNumbers, generateCandidates, withinOneEdit, fuzzyEqual } = __testing__;
 
 describe('checkAnswer', () => {
   it('matches exact answer (case-insensitive)', () => {
@@ -226,5 +226,99 @@ describe('number/text normalization helpers', () => {
     expect(normalizeNumbers('constructor')).toBe('constructor');
     expect(normalizeNumbers('toString four')).toBe('toString 4');
     expect(checkAnswer('__proto__', ['Four (4) years'])).toBe(false);
+  });
+});
+
+describe('withinOneEdit (bounded edit distance)', () => {
+  it('treats identical strings as within one edit', () => {
+    expect(withinOneEdit('president', 'president')).toBe(true);
+  });
+
+  it('accepts a single substitution, insertion, or deletion', () => {
+    expect(withinOneEdit('president', 'presidant')).toBe(true); // substitution
+    expect(withinOneEdit('abc', 'abcd')).toBe(true); // trailing insertion
+    expect(withinOneEdit('abcd', 'abc')).toBe(true); // trailing deletion
+    expect(withinOneEdit('abXc', 'abc')).toBe(true); // interior deletion
+    expect(withinOneEdit('abc', 'abXc')).toBe(true); // interior insertion
+  });
+
+  it('rejects two or more edits and transpositions', () => {
+    expect(withinOneEdit('abc', 'acb')).toBe(false); // transposition = 2 edits
+    expect(withinOneEdit('axc', 'abcd')).toBe(false);
+    expect(withinOneEdit('monarchy', 'democracy')).toBe(false);
+    expect(withinOneEdit('abc', 'abcde')).toBe(false); // length diff 2
+  });
+});
+
+describe('fuzzyEqual (typo-tolerant token equality)', () => {
+  it('is exact for short tokens (<6 chars)', () => {
+    expect(fuzzyEqual('vote', 'vate')).toBe(false);
+    expect(fuzzyEqual('bill', 'hill')).toBe(false);
+    // 5-letter tokens are NOT fuzzed (avoids "state"~"states" style collisions).
+    expect(fuzzyEqual('state', 'stale')).toBe(false);
+    expect(fuzzyEqual('state', 'states')).toBe(false);
+    expect(fuzzyEqual('war', 'war')).toBe(true);
+  });
+
+  it('never fuzzes tokens containing a digit', () => {
+    expect(fuzzyEqual('1776', '1786')).toBe(false);
+    expect(fuzzyEqual('1920s', '1820s')).toBe(false);
+  });
+
+  it('accepts a single edit for longer alphabetic tokens', () => {
+    expect(fuzzyEqual('president', 'presidant')).toBe(true);
+    expect(fuzzyEqual('amendment', 'ammendment')).toBe(true);
+  });
+
+  it('does not treat a pure singular/plural pair as a typo', () => {
+    expect(fuzzyEqual('senators', 'senator')).toBe(false);
+    expect(fuzzyEqual('president', 'presidents')).toBe(false);
+    expect(fuzzyEqual('freedom', 'freedoms')).toBe(false);
+    expect(fuzzyEqual('amendment', 'amendments')).toBe(false);
+  });
+
+  it('still matches a final-"s" deletion typo for words ending in s', () => {
+    expect(fuzzyEqual('congres', 'congress')).toBe(true);
+    expect(checkAnswer('congres', ['(U.S.) Congress'])).toBe(true);
+  });
+});
+
+describe('checkAnswer - typo tolerance (PR2)', () => {
+  it('accepts minor typos in longer words', () => {
+    expect(checkAnswer('presidant', ['the President'])).toBe(true);
+    expect(checkAnswer('freedon of speach', ['freedom of speech'])).toBe(true);
+    expect(checkAnswer('ammendment', ['Amendment'])).toBe(true);
+  });
+
+  it('does not let a lone fuzzy match satisfy a multi-word answer', () => {
+    expect(checkAnswer('Federal Courts', ['Supreme Court'])).toBe(false);
+    expect(checkAnswer('courts', ['Supreme Court'])).toBe(false);
+    expect(checkAnswer('freedon of anything', ['freedom of speech'])).toBe(false);
+  });
+
+  it('does not let a plural-collision fuzzy match cross the overlap bar', () => {
+    // "first" exact + "states"~"state" fuzzy must NOT accept a different answer.
+    expect(
+      checkAnswer('First president of the United States', ['First Secretary of State']),
+    ).toBe(false);
+  });
+
+  it('does not accept a near-plural of a single-word answer from another question', () => {
+    expect(checkAnswer("Presidents Day", ['The President (of the United States)'])).toBe(false);
+    expect(checkAnswer('individual freedoms', ['Freedom'])).toBe(false);
+    expect(checkAnswer('14th Amendment', ['Amendments'])).toBe(false);
+  });
+
+  it('does not inflate matches via repeated user tokens', () => {
+    expect(checkAnswer('presidant presidant', ['President of the United States'])).toBe(false);
+  });
+
+  it('keeps numeric precision: typos never bridge different numbers', () => {
+    expect(checkAnswer('1786', ['1776'])).toBe(false);
+    expect(checkAnswer('5', ['Nine (9)'])).toBe(false);
+  });
+
+  it('does not fuzzy-match two distinct longer words', () => {
+    expect(checkAnswer('Monarchy', ['Democracy'])).toBe(false);
   });
 });

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -463,8 +463,8 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     // typo-tolerant via `fuzzyEqual`, but to avoid false positives we count
     // UNIQUE accepted words matched (so a repeated user token cannot inflate
     // the count) and never let a single fuzzy-only match carry a multi-word
-    // answer (so "Federal Courts" cannot satisfy "Supreme Court" via the lone
-    // near-match "courts"~"court").
+    // answer (so "freedon of religion" cannot satisfy "freedom of speech" via
+    // the lone near-match "freedon"~"freedom").
     if (!userHasRequiredNumber) return false;
     const userWords = userTokens.filter(isSignificant);
     const acceptedWords = [...new Set(primaryTokens.filter(isSignificant))];

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -302,6 +302,75 @@ function isSignificant(token: string): boolean {
 }
 
 /**
+ * Returns true when `a` and `b` are within a single edit (one insertion,
+ * deletion, or substitution) of each other — i.e. Levenshtein distance <= 1.
+ * Implemented as a length-diff short-circuit plus a single linear scan rather
+ * than a full DP table. Transpositions count as two edits and are NOT within
+ * one edit.
+ */
+function withinOneEdit(a: string, b: string): boolean {
+  if (a === b) return true;
+  const la = a.length;
+  const lb = b.length;
+  if (Math.abs(la - lb) > 1) return false;
+
+  let i = 0;
+  let j = 0;
+  let edited = false;
+  while (i < la && j < lb) {
+    if (a[i] === b[j]) {
+      i += 1;
+      j += 1;
+      continue;
+    }
+    if (edited) return false; // a second mismatch => distance >= 2
+    edited = true;
+    if (la > lb) {
+      i += 1; // deletion from a
+    } else if (lb > la) {
+      j += 1; // insertion into a
+    } else {
+      i += 1;
+      j += 1; // substitution
+    }
+  }
+  // A leftover trailing character in the longer string is the single edit; if
+  // we already consumed our one edit, that trailing char makes it two.
+  if ((i < la || j < lb) && edited) return false;
+  return true;
+}
+
+/**
+ * Typo-tolerant token equality used ONLY by the overlap heuristic. Two tokens
+ * are fuzzy-equal when they are identical, or both are long enough (>=6 chars),
+ * contain no digit, are NOT a pure singular/plural pair, and are within a single
+ * edit. The length and digit guards keep short words and every numeric token (a
+ * PR1 precision guarantee) on strict exact matching, so "5" never matches "9"
+ * and "1786" never matches "1776". The >=6 threshold avoids loose 5-letter
+ * collisions such as "state"~"states". The plural guard rejects pairs that
+ * differ only by a trailing "s" (e.g. "president"~"presidents",
+ * "freedom"~"freedoms", "amendment"~"amendments") because that single edit
+ * collapses distinct civics terms that belong to different questions; genuine
+ * substitution typos such as "presidant"~"president" are still accepted. The
+ * guard is skipped when the shorter token already ends in "s" so genuine
+ * final-"s" deletion typos like "congres"~"congress" still match.
+ */
+function fuzzyEqual(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < 6 || b.length < 6) return false;
+  if (/\d/.test(a) || /\d/.test(b)) return false;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  if (
+    !shorter.endsWith('s') &&
+    longer.length === shorter.length + 1 &&
+    longer === `${shorter}s`
+  ) {
+    return false;
+  }
+  return withinOneEdit(a, b);
+}
+
+/**
  * Whole-token contiguous containment: true when `needle` appears as a
  * consecutive run of tokens inside `haystack`. Because matching is per whole
  * token, a numeric token (e.g. "1") can never match a sub-span of a longer
@@ -341,6 +410,12 @@ function containsTokens(haystack: readonly string[], needle: readonly string[]):
  * numeric answers, the lenient paths additionally require the user to supply at
  * least one of the answer's numeric tokens, so the bare noun ("years",
  * "states") cannot match "Four (4) years" or "50 states".
+ *
+ * The overlap heuristic is typo-tolerant (`fuzzyEqual`): a word that is within
+ * one edit of an accepted word (both >=6 chars, no digits) counts as a match,
+ * so "presidant" matches "President". To contain false positives it counts
+ * unique accepted words matched and never lets a lone fuzzy-only match satisfy
+ * a multi-word answer.
  */
 export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string[]): boolean {
   const user = normalizeFull(userAnswer);
@@ -384,14 +459,33 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     }
 
     // Significant-word overlap heuristic (>=50% of accepted words present),
-    // gated on the required numeric token for numeric answers.
+    // gated on the required numeric token for numeric answers. Matching is
+    // typo-tolerant via `fuzzyEqual`, but to avoid false positives we count
+    // UNIQUE accepted words matched (so a repeated user token cannot inflate
+    // the count) and never let a single fuzzy-only match carry a multi-word
+    // answer (so "Federal Courts" cannot satisfy "Supreme Court" via the lone
+    // near-match "courts"~"court").
     if (!userHasRequiredNumber) return false;
     const userWords = userTokens.filter(isSignificant);
-    const acceptedWords = primaryTokens.filter(isSignificant);
+    const acceptedWords = [...new Set(primaryTokens.filter(isSignificant))];
     if (acceptedWords.length === 0) return false;
 
-    const matchingWords = userWords.filter((w) => acceptedWords.includes(w));
-    return matchingWords.length >= Math.ceil(acceptedWords.length * 0.5);
+    let exactMatches = 0;
+    let fuzzyMatches = 0;
+    for (const accepted of acceptedWords) {
+      if (userWords.includes(accepted)) {
+        exactMatches += 1;
+      } else if (userWords.some((w) => fuzzyEqual(w, accepted))) {
+        fuzzyMatches += 1;
+      }
+    }
+    const totalMatches = exactMatches + fuzzyMatches;
+
+    // A lone fuzzy (non-exact) match is too weak to accept a multi-word answer.
+    if (acceptedWords.length >= 2 && totalMatches === 1 && exactMatches === 0) {
+      return false;
+    }
+    return totalMatches >= Math.ceil(acceptedWords.length * 0.5);
   });
 }
 
@@ -401,4 +495,10 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
  * Production code uses `checkAnswer` exclusively; this object exists solely so
  * the unit tests can exercise each pure helper in isolation.
  */
-export const __testing__ = { normalizeText, normalizeNumbers, generateCandidates };
+export const __testing__ = {
+  normalizeText,
+  normalizeNumbers,
+  generateCandidates,
+  withinOneEdit,
+  fuzzyEqual,
+};


### PR DESCRIPTION
## PR2 of #87 — Typo tolerance in the quiz answer checker

This is the second of three sequential PRs addressing #87 (typed-answer checker rejecting valid answers). PR1 (#116, numeric digit↔word equivalence) is merged. This PR adds **bounded single-edit typo tolerance** so minor misspellings of longer civics terms are accepted.

### What changed
All changes are in `src/client/src/utils/answerChecker.ts` (+ tests):

- **`withinOneEdit(a, b)`** — Levenshtein distance ≤ 1 (length-diff short-circuit + single linear scan; transpositions count as two edits).
- **`fuzzyEqual(a, b)`** — identical, or both tokens ≥ 6 chars, neither containing a digit, not a pure singular/plural pair, and within one edit.
  - Length + digit guards keep short words and **every numeric token** on strict exact matching, preserving the PR1 precision guarantees (`5`≠`9`, `1786`≠`1776`).
  - **Plural guard**: pairs differing only by a trailing `s` are rejected so distinct civics terms from different questions don't collide (`Presidents Day` no longer matches `The President`). Skipped when the shorter token already ends in `s`, so genuine deletion typos like `congres`→`Congress` still match.
- **Overlap heuristic** now counts **unique** accepted significant words, matches each exactly or via `fuzzyEqual`, forbids a lone fuzzy-only match from satisfying a multi-word answer, and passes at `totalMatches ≥ ceil(acceptedWords.length * 0.5)`. The PR1 numeric required-token gate runs first, unchanged.

### Examples now accepted
`presidant` → President · `freedon of speach` → freedom of speech · `congres` → Congress · `ammendment` → Amendment

### False-positive sentinels (stay rejected)
`state/states`, `Presidents Day` vs President, `individual freedoms` vs Freedom, `14th Amendment` vs Amendments, `Federal Courts` vs Supreme Court — plus all PR1 numeric sentinels.

### Scope note
Singular/plural acceptance is **deliberately out of scope** here (plurals were already non-matching on `main`); it's deferred to the upcoming paraphrase pass to keep this change purely typo-focused.

### Verification
- Client: 253 tests pass, lint clean (1 pre-existing warning), build OK, bundle within size budget.
- E2E: 39 Playwright tests pass.

Part of #87 (tracker stays open).
