### PR TITLE
feat: whole-answer synonyms in quiz answer checker (#87)

### DIFF
--- a/src/client/src/utils/answerChecker.test.ts
+++ b/src/client/src/utils/answerChecker.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { checkAnswer, __testing__ } from './answerChecker';
 
-const { normalizeNumbers, generateCandidates, withinOneEdit, fuzzyEqual } = __testing__;
+const { normalizeNumbers, generateCandidates, withinOneEdit, fuzzyEqual, sameFullAnswerSynonym } =
+  __testing__;
 
 describe('checkAnswer', () => {
   it('matches exact answer (case-insensitive)', () => {
@@ -320,5 +321,61 @@ describe('checkAnswer - typo tolerance (PR2)', () => {
 
   it('does not fuzzy-match two distinct longer words', () => {
     expect(checkAnswer('Monarchy', ['Democracy'])).toBe(false);
+  });
+});
+
+describe('sameFullAnswerSynonym (whole-answer synonym equivalence)', () => {
+  it('groups country-name variants together (post-normalization)', () => {
+    const us = 'the united states';
+    expect(sameFullAnswerSynonym('united states of america', us)).toBe(true);
+    expect(sameFullAnswerSynonym('america', us)).toBe(true);
+    expect(sameFullAnswerSynonym('usa', us)).toBe(true);
+    // "U.S." and "U.S.A." normalize to "u s" / "u s a".
+    expect(sameFullAnswerSynonym('u s', us)).toBe(true);
+    expect(sameFullAnswerSynonym('u s a', us)).toBe(true);
+  });
+
+  it('groups the national motto with its Latin form (numbers normalized)', () => {
+    // "Out of many, one" normalizes to "out of many 1".
+    expect(sameFullAnswerSynonym('e pluribus unum', 'out of many 1')).toBe(true);
+    expect(sameFullAnswerSynonym('we all become 1', 'out of many 1')).toBe(true);
+  });
+
+  it('does not link members of different groups or unrelated phrases', () => {
+    expect(sameFullAnswerSynonym('america', 'out of many 1')).toBe(false);
+    expect(sameFullAnswerSynonym('usa', 'constitution')).toBe(false);
+    expect(sameFullAnswerSynonym('', 'the united states')).toBe(false);
+    expect(sameFullAnswerSynonym('the united states', '')).toBe(false);
+  });
+});
+
+describe('checkAnswer - whole-answer synonyms (PR3)', () => {
+  it('accepts well-known country-name synonyms for "The United States"', () => {
+    expect(checkAnswer('USA', ['The United States'])).toBe(true);
+    expect(checkAnswer('U.S.A.', ['The United States'])).toBe(true);
+    expect(checkAnswer('U.S.', ['The United States'])).toBe(true);
+    expect(checkAnswer('America', ['The United States'])).toBe(true);
+    expect(checkAnswer('United States of America', ['The United States'])).toBe(true);
+  });
+
+  it('accepts the Latin motto for "Out of many, one"', () => {
+    expect(checkAnswer('E pluribus unum', ['Out of many, one'])).toBe(true);
+  });
+
+  it('does not accept a country synonym for a different question via a parenthetical', () => {
+    // "(U.S.)" inside these answers must NOT make "USA"/"U.S." a correct answer.
+    expect(checkAnswer('USA', ['(U.S.) Constitution'])).toBe(false);
+    expect(checkAnswer('U.S.', ['(U.S.) Congress'])).toBe(false);
+  });
+
+  it('does not accept a country synonym for longer answers that merely contain "United States"', () => {
+    expect(checkAnswer('USA', ['Citizens of the United States'])).toBe(false);
+    expect(checkAnswer('America', ['First president of the United States'])).toBe(false);
+    expect(checkAnswer('United States of America', ['U.S. citizens'])).toBe(false);
+  });
+
+  it('does not let the motto synonym cross to other answers', () => {
+    expect(checkAnswer('E pluribus unum', ['The Star-Spangled Banner'])).toBe(false);
+    expect(checkAnswer('America', ['Out of many, one'])).toBe(false);
   });
 });

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -246,9 +246,12 @@ function normalizeFull(text: string): string {
 }
 
 /**
- * Hand-curated groups of well-known civics paraphrases that are NOT enumerated
- * in the seed data but mean exactly the same thing as a whole answer. Each
- * group is a set of interchangeable WHOLE answers (raw, pre-normalization).
+ * Hand-curated groups of interchangeable WHOLE civics answers. Each group ties
+ * a seed answer to one or more well-known equivalents that are NOT in the seed
+ * data (e.g. "USA"/"America" alongside the seed answer "The United States", and
+ * the Latin "E pluribus unum" alongside the seed motto "Out of many, one"), so
+ * typing any group member is accepted for that answer. Groups are raw,
+ * pre-normalization.
  *
  * These are intentionally tiny and conservative. They are matched ONLY as
  * whole-answer equality against the stripped canonical candidate (see

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -259,7 +259,7 @@ function normalizeFull(text: string): string {
  * NOTE: groups are GLOBAL (not scoped to a question id, which the checker does
  * not receive). When editing this list, audit that no member normalizes to the
  * WHOLE of an unrelated question's accepted answer. Today the only whole answer
- * matching the country group is Q66/Q120's "The United States".
+ * matching the country group is Q66's "The United States".
  */
 const SYNONYM_GROUPS_RAW: readonly (readonly string[])[] = [
   // Country name (e.g. Q66 Pledge of Allegiance, whole answer "The United States").

--- a/src/client/src/utils/answerChecker.ts
+++ b/src/client/src/utils/answerChecker.ts
@@ -245,6 +245,52 @@ function normalizeFull(text: string): string {
   return normalizeNumbers(normalizeText(text));
 }
 
+/**
+ * Hand-curated groups of well-known civics paraphrases that are NOT enumerated
+ * in the seed data but mean exactly the same thing as a whole answer. Each
+ * group is a set of interchangeable WHOLE answers (raw, pre-normalization).
+ *
+ * These are intentionally tiny and conservative. They are matched ONLY as
+ * whole-answer equality against the stripped canonical candidate (see
+ * `sameFullAnswerSynonym`), never fed into the token containment or overlap
+ * heuristics, so they add zero new partial-match surface and cannot, on their
+ * own, accept a wrong answer for a different question.
+ *
+ * NOTE: groups are GLOBAL (not scoped to a question id, which the checker does
+ * not receive). When editing this list, audit that no member normalizes to the
+ * WHOLE of an unrelated question's accepted answer. Today the only whole answer
+ * matching the country group is Q66/Q120's "The United States".
+ */
+const SYNONYM_GROUPS_RAW: readonly (readonly string[])[] = [
+  // Country name (e.g. Q66 Pledge of Allegiance, whole answer "The United States").
+  [
+    'the United States',
+    'United States',
+    'United States of America',
+    'America',
+    'USA',
+    'U.S.',
+    'U.S.A.',
+  ],
+  // National motto (Q124, whole answer "Out of many, one"); "E pluribus unum"
+  // is the well-known Latin form not present in the seed data.
+  ['Out of many, one', 'We all become one', 'E pluribus unum'],
+];
+
+const SYNONYM_GROUPS: ReadonlyArray<ReadonlySet<string>> = SYNONYM_GROUPS_RAW.map(
+  (group) => new Set(group.map(normalizeFull).filter((s) => s.length > 0)),
+);
+
+/**
+ * True when two ALREADY-normalized whole answers belong to the same curated
+ * synonym group. Used as an exact-only equivalence alongside literal equality;
+ * deliberately not used by any lenient (containment/overlap) path.
+ */
+function sameFullAnswerSynonym(a: string, b: string): boolean {
+  if (a.length === 0 || b.length === 0) return false;
+  return SYNONYM_GROUPS.some((group) => group.has(a) && group.has(b));
+}
+
 function tokenize(text: string): string[] {
   return text.split(' ').filter((t) => t.length > 0);
 }
@@ -416,6 +462,11 @@ function containsTokens(haystack: readonly string[], needle: readonly string[]):
  * so "presidant" matches "President". To contain false positives it counts
  * unique accepted words matched and never lets a lone fuzzy-only match satisfy
  * a multi-word answer.
+ *
+ * A small curated set of whole-answer synonyms (`sameFullAnswerSynonym`, e.g.
+ * "USA"/"America" for "The United States", "E pluribus unum" for the motto) is
+ * accepted alongside exact equality. These are matched only as whole answers
+ * against the stripped candidate and never feed the lenient paths.
  */
 export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string[]): boolean {
   const user = normalizeFull(userAnswer);
@@ -431,6 +482,13 @@ export function checkAnswer(userAnswer: string, acceptedAnswers: readonly string
     // Lenient matching only against the STRIPPED (canonical) candidate.
     const primary = candidates[0];
     if (primary.length === 0) return false;
+
+    // Curated whole-answer synonym equivalence (e.g. "USA" for "The United
+    // States", "E pluribus unum" for "Out of many, one"). Checked only against
+    // the stripped canonical form so parenthetical fragments (e.g. the "U.S."
+    // inside "(U.S.) Constitution") can never trigger it.
+    if (sameFullAnswerSynonym(user, primary)) return true;
+
     const primaryTokens = tokenize(primary);
 
     // When the canonical answer contains number(s), the user's input must
@@ -501,4 +559,5 @@ export const __testing__ = {
   generateCandidates,
   withinOneEdit,
   fuzzyEqual,
+  sameFullAnswerSynonym,
 };


### PR DESCRIPTION
## PR3 of #87 — Whole-answer synonyms in the quiz answer checker

Third and final PR for #87. PR1 (#116, numeric digit↔word) and PR2 (#117, typo tolerance) are merged. This PR accepts a few well-known civics paraphrases that aren't enumerated in the seed data, with a deliberately tiny and false-positive-safe design.

### What changed
All in `src/client/src/utils/answerChecker.ts` (+ tests):

- **`SYNONYM_GROUPS_RAW`** — raw interchangeable **whole** answers per group:
  - Country name → `The United States`: `USA`, `U.S.`, `U.S.A.`, `America`, `United States of America`.
  - National motto → `Out of many, one`: `E pluribus unum` (Latin), `We all become one`.
- Each member is normalized through the existing `normalizeFull` at module init (so `one`→`1`, `U.S.`→`u s`) into Sets.
- **`sameFullAnswerSynonym(a, b)`** — true only when both already-normalized **whole** strings are in the same group.
- `checkAnswer` applies it as an **exact-only** equivalence alongside literal equality, matched **only against the stripped canonical candidate** — never the paren-unwrapped/paren-contents forms, and never fed into the containment or overlap heuristics.

### Newly accepted
`USA` / `America` / `U.S.` / `United States of America` → "The United States" (e.g. Q66 Pledge) · `E pluribus unum` → "Out of many, one" (Q124).

### False-positive safety (sentinels in tests)
- `USA` ✗ `(U.S.) Constitution` — the `(U.S.)` paren fragment can't trigger it because synonyms only match the stripped primary (`constitution`).
- `USA` ✗ `Citizens of the United States`, `America` ✗ `First president of the United States` — whole-answer-only matching never leaks into longer answers that merely contain "United States".
- Motto synonyms don't cross to other answers.
- All PR1 numeric and PR2 typo guarantees preserved.

### Design note
Synonym groups are **global** (the checker doesn't receive a question id) and are documented in-code as requiring a collision audit when edited. The whole-answer-only + stripped-primary-only design keeps the new surface minimal.

### Verification
- Client: 261 tests pass, lint clean (1 pre-existing warning), build OK, bundle within size budget.
- E2E: 39 Playwright tests pass.

Completes #87 (numeric → typo → paraphrase).
